### PR TITLE
Fixed - JBIDE-12858 - NPE when validating HttpMethod

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorDelegate.java
@@ -55,12 +55,17 @@ public class JaxrsHttpMethodValidatorDelegate extends AbstractJaxrsElementValida
 	 * @throws JavaModelException
 	 */
 	private void validateHttpMethodAnnotation(final JaxrsHttpMethod httpMethod) throws JavaModelException {
-		final Annotation annotation = httpMethod.getHttpMethodAnnotation();
-		if (annotation != null) { // if annotation is null, the resource is not a JaxrsHttpMethod anymore.
-			final String httpValue = annotation.getValue("value");
-			if (httpValue == null || httpValue.isEmpty()) {
-				final ISourceRange range = JdtUtils.resolveMemberPairValueRange(annotation.getJavaAnnotation(),
-						annotation.getFullyQualifiedName(), "value");
+		final Annotation httpMethodAnnotation = httpMethod.getHttpMethodAnnotation();
+		if (httpMethodAnnotation != null) { // if annotation is null, the resource is not a JaxrsHttpMethod anymore.
+			final String httpValue = httpMethodAnnotation.getValue("value");
+			if (httpValue == null) {
+				final ISourceRange range = httpMethodAnnotation.getJavaAnnotation().getNameRange();
+				addProblem(JaxrsValidationMessages.HTTP_METHOD_INVALID_HTTP_METHOD_ANNOTATION_VALUE,
+						JaxrsPreferences.HTTP_METHOD_INVALID_HTTP_METHOD_ANNOTATION_VALUE, new String[0],
+						range.getLength(), range.getOffset(), httpMethod.getResource());
+			} else if (httpValue.isEmpty()) {
+				final ISourceRange range = JdtUtils.resolveMemberPairValueRange(httpMethodAnnotation.getJavaAnnotation(),
+						httpMethodAnnotation.getFullyQualifiedName(), "value");
 				addProblem(JaxrsValidationMessages.HTTP_METHOD_INVALID_HTTP_METHOD_ANNOTATION_VALUE,
 						JaxrsPreferences.HTTP_METHOD_INVALID_HTTP_METHOD_ANNOTATION_VALUE, new String[0],
 						range.getLength(), range.getOffset(), httpMethod.getResource());

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/AbstractCommonTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/AbstractCommonTestCase.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.core.JavaProject;
+import org.jboss.tools.ws.jaxrs.core.jdt.CompilationUnitsRepository;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -130,6 +131,11 @@ public abstract class AbstractCommonTestCase {
 			long endTime = new Date().getTime();
 			LOGGER.info("Test Workspace setup in " + (endTime - startTime) + "ms.");
 		}
+	}
+	
+	@Before
+	public void clearCompilationUnitsRepository() {
+		CompilationUnitsRepository.getInstance().clear();
 	}
 
 	@After

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/CompilationUnitsRepositoryTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/CompilationUnitsRepositoryTestCase.java
@@ -42,12 +42,6 @@ public class CompilationUnitsRepositoryTestCase extends AbstractCommonTestCase {
 
 	private CompilationUnitsRepository repository = null;
 
-	@Before
-	public void setup() {
-		repository = CompilationUnitsRepository.getInstance();
-		repository.clear();
-	}
-
 	private IType getType(String typeName) throws CoreException {
 		return JdtUtils.resolveType(typeName, javaProject, progressMonitor);
 	}
@@ -56,6 +50,11 @@ public class CompilationUnitsRepositoryTestCase extends AbstractCommonTestCase {
 		return WorkbenchUtils.getMethod(parentType, methodName);
 	}
 
+	@Before
+	public void setup() {
+		repository = CompilationUnitsRepository.getInstance();
+	}
+	
 	@Test
 	public void shouldGetASTByCompilationUnit() throws CoreException {
 		// pre-conditions


### PR DESCRIPTION
- distinguishing when annotation value is null vs empty, 
- clearing
  compilationunitsrepository before each test method to ensure
  test isolation
