### PR TITLE
Fixed - JBIDE-13113 - JAX-RS validator moved into the root of preference...

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.ui/plugin.xml
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/plugin.xml
@@ -395,7 +395,7 @@
       <page
             category="org.jboss.tools.common.model.ui.MainPreferencePage"
             class="org.jboss.tools.ws.jaxrs.ui.preferences.JaxrsPreferencePage"
-            id="org.jboss.tools.ws.jaxrs.ui.preferencePages.JAXRSPreferencePage"
+            id="org.jboss.tools.ws.jaxrs.ui"
             name="%PreferencePage">
       </page>
    </extension>


### PR DESCRIPTION
...s

Setting (back) the correct id to the JAX-RS page, matching the category of the JAX-RS Validator page
