### PR TITLE
JBIDE-14616: remove parent.relativePath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,6 @@
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
 		<version>4.1.0.Beta1-SNAPSHOT</version>
-		<relativePath>../jbosstools-build/parent/pom.xml</relativePath>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>ws</artifactId>


### PR DESCRIPTION
- To avoid issue with sync of local parent & remote (Nexus) parent
- Make local build behave more like CI build
