### PR TITLE
JBIDE-13580 - NPE when duplicating Java Method

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScanner.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScanner.java
@@ -116,10 +116,11 @@ public class JavaElementDeltaScanner {
 				// FIXME: must make sure that the methodDeclarationsMap remains
 				// in sync with the working copy after each change.
 				boolean computeDiffs = requiresDiffsComputation(flags);
-				List<JavaMethodSignature> diffs = compilationUnitsRepository.mergeAST(compilationUnit,
+				Map<String, JavaMethodSignature> diffs = compilationUnitsRepository.mergeAST(compilationUnit,
 						compilationUnitAST, computeDiffs);
-				for (JavaMethodSignature diff : diffs) {
-					final JavaElementDelta event = new JavaElementDelta(diff.getJavaMethod(), CHANGED, eventType,
+				for (Entry<String, JavaMethodSignature> diff : diffs.entrySet()) {
+					JavaMethodSignature methodSignature = diff.getValue();
+					final JavaElementDelta event = new JavaElementDelta(methodSignature.getJavaMethod(), CHANGED, eventType,
 							compilationUnitAST, F_SIGNATURE);
 					if (javaElementChangedEventFilter.apply(event)) {
 						events.add(event);

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsJavaElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsJavaElement.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.DeltaFlags;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
+import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils.MapComparison;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementKind;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
@@ -230,18 +231,16 @@ public abstract class JaxrsJavaElement<T extends IMember> extends JaxrsBaseEleme
 	}
 
 	DeltaFlags updateAnnotations(final Map<String, Annotation> otherAnnotations) {
-		DeltaFlags flags = new DeltaFlags();
+		final DeltaFlags flags = new DeltaFlags();
+		final MapComparison<String, Annotation> annotationsComparison = CollectionUtils.compare(this.annotations, otherAnnotations);
 		// added annotations (ie: found in 'otherAnnotation' but not
 		// this.annotations)
-		final Map<String, Annotation> addedAnnotations = CollectionUtils.difference(otherAnnotations, this.annotations);
+		final Map<String, Annotation> addedAnnotations = annotationsComparison.getAddedItems();
 		// removed annotations (ie: found in this.annotations but not in
 		// 'otherAnnotation')
-		final Map<String, Annotation> removedAnnotations = CollectionUtils.difference(this.annotations,
-				otherAnnotations);
-		// may-be-changed annotations (ie: available in both collections, but
-		// not sure all values are equal)
-		final Map<String, Annotation> changedAnnotations = CollectionUtils.intersection(otherAnnotations,
-				this.annotations);
+		final Map<String, Annotation> removedAnnotations = annotationsComparison.getRemovedItems();
+		// changed annotations 
+		final Map<String, Annotation> changedAnnotations = annotationsComparison.getChangedItems();
 		for (Entry<String, Annotation> entry : addedAnnotations.entrySet()) {
 			flags.addFlags(internalAddAnnotation(entry.getValue()));
 		}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -412,7 +412,6 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	 */
 	private void processJavaElementChange(final IJavaElement element, final int deltaKind, final CompilationUnit ast,
 			final IProgressMonitor progressMonitor) throws JavaModelException, CoreException {
-		// FIXME : refactor/rewrite this method block
 		if (deltaKind == ADDED) {
 			JaxrsElementFactory.createElements(element, ast, this, progressMonitor);
 		} else {
@@ -676,15 +675,15 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	// ********************************************************************************
 
 	/**
-	 * Adds the given element into the JAX-RS Metamodel, including its
-	 * indexation.
+	 * Adds the given {@link IJaxrsElement} element into the JAX-RS Metamodel, including its
+	 * indexation if the underlying {@link IJavaElement} is not already part of the metamodel (avoiding duplicate elements)
 	 * 
 	 * @param element
 	 *            the element to add
 	 * @throws CoreException
 	 */
 	public void add(final IJaxrsElement element) throws CoreException {
-		if (element == null) {
+		if (element == null || findElementByIdentifier(element.getIdentifier()) != null) {
 			return;
 		}
 		this.elements.put(element.getIdentifier(), element);
@@ -912,6 +911,18 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 		return searchJaxrsElement(resourcePathTerm);
 	}
 
+	/**
+	 * Searches and returns the JAX-RS Element matching the given
+	 * Identifier, or null if no element with the same identifier already exists in the Metamodel
+	 * 
+	 * @param identifier
+	 *            the element identifier (as returned by {@link IJaxrsElement#getIdentifier()})
+	 * @return the JAX-RS Element matching the given identifier or <code>null</code>.
+	 */
+	private IJaxrsElement findElementByIdentifier(final String identifier) {
+		return searchJaxrsElement(new Term(FIELD_IDENTIFIER, identifier));
+	}
+	
 	/**
 	 * Searches and returns all JAX-RS Java-based Elements matching the given
 	 * {@link IJavaElement}, which can be {@link Annotation} {@link IProject}, {@link IPackageFragmentRoot}, {@link ICompilationUnit} or an {@link IMember}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsResource.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsResource.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.DeltaFlags;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
+import org.jboss.tools.ws.jaxrs.core.jdt.JavaMethodSignature;
 import org.jboss.tools.ws.jaxrs.core.jdt.JaxrsElementsSearcher;
 import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementKind;
@@ -134,6 +135,8 @@ public class JaxrsResource extends JaxrsJavaElement<IType> implements IJaxrsReso
 					PRODUCES.qualifiedName, ENCODED.qualifiedName);
 			// create the resource
 			final JaxrsResource resource = new JaxrsResource(this);
+			// retrieve all JavaMethodSignatures at once
+			final Map<String, JavaMethodSignature> methodSignatures = JdtUtils.resolveMethodSignatures(javaType, ast);
 			// find the resource methods, subresource methods and
 			// subresource
 			// locators of this resource:
@@ -141,7 +144,7 @@ public class JaxrsResource extends JaxrsJavaElement<IType> implements IJaxrsReso
 					new NullProgressMonitor());
 			for (IMethod javaMethod : javaMethods) {
 				JaxrsResourceMethod.from(javaMethod, ast, httpMethods).withParentResource(resource)
-						.withMetamodel(metamodel).build();
+						.withJavaMethodSignature(methodSignatures.get(javaMethod.getHandleIdentifier())).withMetamodel(metamodel).build();
 			}
 			// find the available type fields
 			for (IField javaField : javaType.getFields()) {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsResourceMethod.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsResourceMethod.java
@@ -98,6 +98,7 @@ public class JaxrsResourceMethod extends JaxrsResourceElement<IMethod> implement
 		private IType returnedJavaType = null;
 		private List<JavaMethodParameter> javaMethodParameters = new ArrayList<JavaMethodParameter>();
 		private JaxrsMetamodel metamodel;
+		private JavaMethodSignature methodSignature;
 
 		public Builder(final IMethod javaMethod, final CompilationUnit ast, final List<IJaxrsHttpMethod> httpMethods) {
 			this.javaMethod = javaMethod;
@@ -107,6 +108,11 @@ public class JaxrsResourceMethod extends JaxrsResourceElement<IMethod> implement
 
 		public Builder withMetamodel(final JaxrsMetamodel metamodel) {
 			this.metamodel = metamodel;
+			return this;
+		}
+		
+		public Builder withJavaMethodSignature(final JavaMethodSignature javaMethodSignature) {
+			this.methodSignature = javaMethodSignature;
 			return this;
 		}
 
@@ -138,17 +144,20 @@ public class JaxrsResourceMethod extends JaxrsResourceElement<IMethod> implement
 						javaMethod.getParent().getElementName(), javaMethod.getElementName());
 				return null;
 			}
-			final JavaMethodSignature methodSignature = JdtUtils.resolveMethodSignature(javaMethod, ast);
+			// if method signature was not provided before.
+			if(methodSignature == null) {
+				methodSignature = JdtUtils.resolveMethodSignature(javaMethod, ast);
+			}
 			// avoid creating Resource Method when the Java Method cannot be
 			// parsed (ie, syntax/compilation error)
-			if (methodSignature != null) {
-				javaMethodParameters = methodSignature.getMethodParameters();
-				returnedJavaType = methodSignature.getReturnedType();
-				final JaxrsResourceMethod resourceMethod = new JaxrsResourceMethod(this);
-				resourceMethod.joinMetamodel();
-				return resourceMethod;
+			if (methodSignature == null) {
+				return null;
 			}
-			return null;
+			javaMethodParameters = methodSignature.getMethodParameters();
+			returnedJavaType = methodSignature.getReturnedType();
+			final JaxrsResourceMethod resourceMethod = new JaxrsResourceMethod(this);
+			resourceMethod.joinMetamodel();
+			return resourceMethod;
 		}
 
 	}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/BindingUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/BindingUtils.java
@@ -48,7 +48,7 @@ public class BindingUtils {
 	 * @param javaAnnotation
 	 * @return
 	 */
-	public static Annotation toAnnotation(IAnnotationBinding annotationBinding, IAnnotation javaAnnotation) {
+	public static Annotation toAnnotation(final IAnnotationBinding annotationBinding, final IAnnotation javaAnnotation) {
 		// return null if underlying java annotation does not exists or is not found (eg: compilation error in the compilation unit)
 		if(javaAnnotation == null) {
 			return null;

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JavaAnnotationsVisitor.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JavaAnnotationsVisitor.java
@@ -181,7 +181,11 @@ public class JavaAnnotationsVisitor extends ASTVisitor {
 					final String qualifiedName = annotationBinding.getAnnotationType().getQualifiedName();
 					final String name = annotationBinding.getAnnotationType().getName();
 					if (annotationNames.contains(qualifiedName) || annotationNames.contains(name)) {
-						annotations.add(BindingUtils.toAnnotation(annotationBinding));
+						final Annotation annotation = BindingUtils.toAnnotation(annotationBinding);
+						// returned Annotation may be null in case of compilation error in the source code, for example.
+						if(annotation != null) {
+							annotations.add(annotation);
+						}
 					}
 				}
 			}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JavaMethodParameter.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JavaMethodParameter.java
@@ -14,7 +14,6 @@ package org.jboss.tools.ws.jaxrs.core.jdt;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils.MapComparison;
@@ -100,19 +99,7 @@ public class JavaMethodParameter {
 	public boolean hasChanges(final JavaMethodParameter otherMethodParameter) {
 		final Map<String, Annotation> otherAnnotations = otherMethodParameter.getAnnotations();
 		final MapComparison<String, Annotation> comparison = CollectionUtils.compare(this.annotations, otherAnnotations);
-		if(!comparison.getAddedItems().isEmpty()) {
-			return true;
-		}
-		if(!comparison.getRemovedItems().isEmpty()) {
-			return true;
-		}
-		// update the remaining annotations'location
-		for (Entry<String, Annotation> entry : comparison.getItemsInCommon().entrySet()) {
-			if(this.annotations.get(entry.getKey()).hasChanges(otherAnnotations.get(entry.getKey()))) {
-				return true;
-			}
-		}
-		return false;
+		return comparison.hasDifferences();
 	}
 	
 	@Override

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtils.java
@@ -664,7 +664,7 @@ public final class JdtUtils {
 		return arguments;
 	}
 
-	public static List<JavaMethodSignature> resolveMethodSignatures(IType type, CompilationUnit ast) {
+	public static Map<String, JavaMethodSignature> resolveMethodSignatures(IType type, CompilationUnit ast) {
 		JavaMethodSignaturesVisitor methodsVisitor = new JavaMethodSignaturesVisitor();
 		ast.accept(methodsVisitor);
 		return methodsVisitor.getMethodSignatures();

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsMetamodel.java
@@ -11,14 +11,9 @@
 package org.jboss.tools.ws.jaxrs.core.metamodel.domain;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IMember;
-import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 
 public interface IJaxrsMetamodel {
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedProcessingTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedProcessingTestCase.java
@@ -1849,6 +1849,23 @@ public class JavaElementChangedProcessingTestCase extends AbstractCommonTestCase
 	}
 
 	@Test
+	public void shouldDoFailWhenDuplicatingJavaMethod() throws CoreException {
+		// pre-conditions
+		final JaxrsResource resource = createResource("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final IMethod method = getJavaMethod(resource.getJavaElement(), "getCustomer");
+		resetElementChangesNotifications();
+		// before operation: metamodel has 6 built-in HTTP Methods + 1 resource + 6 methods
+		assertThat(metamodel.findElements(javaProject).size(), equalTo(13));
+		// operation
+		final IMethod addedMethod = WorkbenchUtils.createMethod(method.getDeclaringType(), method.getSource(), true);
+		processEvent(addedMethod, ADDED);
+		// verifications
+		assertThat(elementChanges.size(), equalTo(0));
+		// after operation: metamodel has still 6 built-in HTTP Methods + 1 resource + 6 methods
+		assertThat(metamodel.findElements(javaProject).size(), equalTo(13));
+	}
+	
+	@Test
 	@Ignore
 	public void shouldUpdateResourceMethodWhenAddingThrowsException() throws CoreException {
 		fail("Not implemented yet - postponed along with support for providers");

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/utils/CollectionUtilsTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/utils/CollectionUtilsTestCase.java
@@ -214,7 +214,7 @@ public class CollectionUtilsTestCase {
 	}
 
 	@Test
-	public void shouldNotFindDifferencesInMapsOfSameSizeWithDifferentValues() {
+	public void shouldFindDifferencesInMapsOfSameSizeWithDifferentValues() {
 		// preconditions
 		Map<String, String> control = new HashMap<String, String>() {
 			{
@@ -233,7 +233,8 @@ public class CollectionUtilsTestCase {
 		// operation
 		Map<String, String> diffs = CollectionUtils.difference(control, test);
 		// verifications
-		assertThat(diffs.size(), equalTo(0));
+		assertThat(diffs.size(), equalTo(1));
+		assertThat(diffs.get("a"), equalTo("one+"));
 	}
 
 	@Test
@@ -261,7 +262,7 @@ public class CollectionUtilsTestCase {
 	}
 
 	@Test
-	public void shouldNotFindDifferencesInMapsOfDifferentSizeWithDifferentValues() {
+	public void shouldFindDifferencesInMapsOfDifferentSizeWithDifferentValues() {
 		// preconditions
 		Map<String, String> control = new HashMap<String, String>() {
 			{
@@ -282,7 +283,8 @@ public class CollectionUtilsTestCase {
 		// operation
 		Map<String, String> diffs = CollectionUtils.difference(control, test);
 		// verifications
-		assertThat(diffs.size(), equalTo(0));
+		assertThat(diffs.size(), equalTo(1));
+		assertThat(diffs.get("a"), equalTo("one+"));
 	}
 
 	@Test
@@ -529,8 +531,8 @@ public class CollectionUtilsTestCase {
 		MapComparison<String, String> diffs = CollectionUtils.compare(control, test);
 		// verifications
 		assertThat(diffs.getAddedItems().keySet(), containsInAnyOrder("d"));
-		assertThat(diffs.getItemsInCommon().keySet(), containsInAnyOrder("a", "b"));
-		assertThat(diffs.getItemsInCommon().get("b"), equalTo("2"));
+		assertThat(diffs.getChangedItems().keySet(), containsInAnyOrder("b"));
+		assertThat(diffs.getChangedItems().get("b"), equalTo("two"));
 		assertThat(diffs.getRemovedItems().keySet(), containsInAnyOrder("c"));
 	}
 	

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/CompilationUnitsRepositoryTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/CompilationUnitsRepositoryTestCase.java
@@ -17,7 +17,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
@@ -79,7 +78,7 @@ public class CompilationUnitsRepositoryTestCase extends AbstractCommonTestCase {
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(method, "@PathParam(\"id\") Integer id",
 				"@PathParam(\"ide\") Integer id", true);
 		final CompilationUnit ast = JdtUtils.parse(compilationUnit, progressMonitor);
-		final List<JavaMethodSignature> diffs = repository.mergeAST(compilationUnit, ast, true);
+		final Map<String, JavaMethodSignature> diffs = repository.mergeAST(compilationUnit, ast, true);
 		// verification
 		assertThat(diffs.size(), equalTo(1));
 	}
@@ -96,7 +95,7 @@ public class CompilationUnitsRepositoryTestCase extends AbstractCommonTestCase {
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(method, "@PathParam(\"id\") Integer id",
 				"@PathParam(\"ide\") Integer id", true);
 		final CompilationUnit ast = JdtUtils.parse(compilationUnit, progressMonitor);
-		final List<JavaMethodSignature> diffs = repository.mergeAST(compilationUnit, ast, false);
+		final Map<String, JavaMethodSignature> diffs = repository.mergeAST(compilationUnit, ast, false);
 		// verification
 		assertThat(diffs.size(), equalTo(0));
 	}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtilsTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtilsTestCase.java
@@ -514,11 +514,11 @@ public class JdtUtilsTestCase extends AbstractCommonTestCase {
 		// preconditions
 		final IType type = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		// operation
-		final List<JavaMethodSignature> methodSignatures = JdtUtils.resolveMethodSignatures(type,
+		final Map<String, JavaMethodSignature> methodSignatures = JdtUtils.resolveMethodSignatures(type,
 				JdtUtils.parse(type, progressMonitor));
 		// verification
 		Assert.assertEquals(7, methodSignatures.size());
-		for (JavaMethodSignature methodSignature : methodSignatures) {
+		for (JavaMethodSignature methodSignature : methodSignatures.values()) {
 			for (JavaMethodParameter methodParameter : methodSignature.getMethodParameters()) {
 				for (Entry<String, Annotation> annotationEntry : methodParameter.getAnnotations().entrySet()) {
 					assertNotNull("JavaAnnotation for " + methodParameter.getName() + "." + annotationEntry.getKey()
@@ -555,7 +555,7 @@ public class JdtUtilsTestCase extends AbstractCommonTestCase {
 		// preconditions
 		final IType type = getType("org.jboss.tools.ws.jaxrs.sample.services.ParameterizedResource");
 		// operation
-		final List<JavaMethodSignature> methodSignatures = JdtUtils.resolveMethodSignatures(type,
+		final Map<String, JavaMethodSignature> methodSignatures = JdtUtils.resolveMethodSignatures(type,
 				JdtUtils.parse(type, progressMonitor));
 		// verification
 		Assert.assertEquals(1, methodSignatures.size());


### PR DESCRIPTION
Ignore Method bindings if they are null.
Also rework on CollectionUtils to compare maps
When creating JAX-RS Resource, retrieve all Java Method Signatures at once if possible (avoid multiple call to visitor)
