### PR TITLE
JBIDE-14913 - JAX-RS Web Services node is empty after project import or workbench startup

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsMetamodelBuilder.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsMetamodelBuilder.java
@@ -93,9 +93,9 @@ public class JaxrsMetamodelBuilder extends IncrementalProjectBuilder {
 	 *            the progress monitor
 	 */
 	private void build(final int buildKind, final IProject project, final IProgressMonitor progressMonitor) {
-		Logger.debug("Building JAX-RS metamodel for project " + project.getName());
+		Logger.debug("Building JAX-RS metamodel for project '" + project.getName() + "'");
 		ResourceChangedBuildJob job = new ResourceChangedBuildJob(project, getResourceChangeEvent(project, buildKind));
-		job.setRule(MutexJobSchedulingRule.getInstance());
+		job.setRule(new MutexJobSchedulingRule(project));
 		job.schedule();
 		try {
 			job.join();
@@ -121,7 +121,7 @@ public class JaxrsMetamodelBuilder extends IncrementalProjectBuilder {
 	private void logBuild(final int kind, @SuppressWarnings("rawtypes") final Map args, final IProject project) {
 		StringBuilder sb = new StringBuilder("JAX-RS Builder called after '");
 		sb.append(ConstantUtils.getStaticFieldName(IncrementalProjectBuilder.class, kind));
-		sb.append("' on project ").append(project.getName());
+		sb.append("' on project '").append(project.getName()).append("'");
 		Logger.debug(sb.toString());
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/MutexJobSchedulingRule.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/MutexJobSchedulingRule.java
@@ -10,35 +10,46 @@
  ******************************************************************************/
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 /**
+ * Mutex Scheduling Rule to avoid concurrent JAX-RS Metamodel Build jobs on the same project.
+ * 
  * @author Xavier Coulon
  *
  */
 public class MutexJobSchedulingRule implements ISchedulingRule {
 
-	private final static MutexJobSchedulingRule instance = new MutexJobSchedulingRule();
+	private final IProject project;
 	
 	/** 
 	 * Private singleton constructor
 	 */
-	private MutexJobSchedulingRule() {
+	public MutexJobSchedulingRule(final IProject project) {
 		super();
-	}
-	
-	public static MutexJobSchedulingRule getInstance() {
-		return instance;
+		this.project = project;
 	}
 	
 	@Override
-	public boolean contains(ISchedulingRule rule) {
+	public boolean contains(final ISchedulingRule rule) {
 		return rule == this;
 	}
 
+	/**
+	 * Returns true if the given {@link ISchedulingRule} is a {@link MutexJobSchedulingRule} and applies on the same {@link IProject} 
+	 */
 	@Override
-	public boolean isConflicting(ISchedulingRule rule) {
-		return rule == this;
+	public boolean isConflicting(final ISchedulingRule otherRule) {
+		return (otherRule instanceof MutexJobSchedulingRule && ((MutexJobSchedulingRule)otherRule).getProject().equals(this.project));
+	}
+
+
+	/**
+	 * @return the project
+	 */
+	public IProject getProject() {
+		return project;
 	}
 
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -154,6 +154,9 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	/** The Listeners for JAX-RS Endpoint changes. */
 	final Set<IJaxrsEndpointChangedListener> endpointChangedListeners = new HashSet<IJaxrsEndpointChangedListener>();
 
+	/** A boolean marker that indicates if the metamodel is being initialized (ie, first/full build).*/
+	private boolean initializing=true;
+
 	/**
 	 * Full constructor.
 	 * 
@@ -170,6 +173,12 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 		indexationService = new JaxrsElementsIndexationDelegate();
 		addBuiltinHttpMethods();
 	}
+	
+	@Override
+	public boolean isInitializing() {
+		return this.initializing;
+	}
+	
 
 	/**
 	 * Resets the problem level for this given element.
@@ -306,7 +315,9 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	 */
 	@Override
 	public void addListener(final IJaxrsEndpointChangedListener listener) {
-		this.endpointChangedListeners.add(listener);
+		if(!endpointChangedListeners.contains(listener)) { 
+			this.endpointChangedListeners.add(listener);
+		}
 	}
 
 	/**
@@ -543,6 +554,7 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	public void processProject(final IProgressMonitor progressMonitor) throws CoreException {
 		// start with a fresh new metamodel
 		try {
+			this.initializing = true;
 			progressMonitor.beginTask("Processing project '" + getProject().getName() + "'...", 1);
 			this.elements.clear();
 			this.endpoints.clear();
@@ -560,7 +572,7 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 		} finally {
 			progressMonitor.done();
 			Logger.debug("Done processing resource results.");
-
+			this.initializing = false;
 		}
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsMetamodel.java
@@ -17,6 +17,12 @@ import org.eclipse.jdt.core.IJavaElement;
 
 public interface IJaxrsMetamodel {
 
+	/**
+	 * Returns <code>true</code> if the JAX-RS Metamodel is being initialized, false if it has already been initialized.
+	 * @return <code>true</code> if the JAX-RS Metamodel is being initialized, false if it has already been initialized.
+	 */
+	public abstract boolean isInitializing();
+	
 	public abstract Collection<IJaxrsEndpoint> getAllEndpoints();
 
 	/**
@@ -27,12 +33,12 @@ public interface IJaxrsMetamodel {
 	 *            the Java Element
 	 * @return the JAX-RS Element or null if none matches.
 	 */
-	public IJaxrsElement findElement(final IJavaElement javaElement);
+	public abstract IJaxrsElement findElement(final IJavaElement javaElement);
 	
 	public abstract IProject getProject();
 
 	public abstract void addListener(IJaxrsEndpointChangedListener listener);
 
-	void removeListener(IJaxrsEndpointChangedListener listener);
+	public void removeListener(IJaxrsEndpointChangedListener listener);
 
 }


### PR DESCRIPTION
displaying the "Loading..." node when the Metamodel is being built
Using a proper Mutex Rule to avoid multiple concurrent builds
Registering the Metamodel Listener at the right moment and only once, so that changes
can be applied on the UI
