### PR TITLE
JBIDE-14988 - Remove missing/old jars from build configuration

### DIFF
--- a/plugins/org.jboss.tools.ws.wise.ui/build.properties
+++ b/plugins/org.jboss.tools.ws.wise.ui/build.properties
@@ -62,6 +62,4 @@ bin.includes = META-INF/,\
                lib/xmlschema-core-2.0.3.jar,\
                lib/xpp3_min-1.1.3.4.O.jar,\
                lib/xstream-1.2.2.jar,\
-               lib/jaxb-impl-2.2.5.1.jar,\
-               lib/jaxb-xjc-2.2.5.1.jar,\
                plugin.xml


### PR DESCRIPTION
Rollback on build.properties to get Jenkins pass the build
