### PR TITLE
JBIDE-13542 - Disappearance of validation warning

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidator.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidator.java
@@ -118,16 +118,18 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 			if (!changedFiles.isEmpty()) {
 				Logger.debug("*** Validating project {} after files {} changed... ***", project.getName(),
 						changedFiles.toString());
-				final JaxrsMetamodel jaxrsMetamodel = JaxrsMetamodelLocator.get(project);
-				if (jaxrsMetamodel != null) { // prevent failure in case
-												// validation would be called at
-												// workbench startup, even
-												// before metamodel is built.
-					final Set<IResource> allResources = completeValidationSet(jaxrsMetamodel,
+				final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+				// prevent failure in case validation would be called at
+				// workbench startup, even before metamodel is built.
+				if (metamodel != null) {
+					// validate each JAX-RS element individually
+					final Set<IResource> allResources = completeValidationSet(metamodel,
 							changedFiles.toArray(new IFile[changedFiles.size()]));
 					for (IResource changedResource : allResources) {
-						validate(reporter, changedResource, jaxrsMetamodel);
+						validate(reporter, changedResource, metamodel);
 					}
+					// validate at the metamodel level for cross-elements validation
+					validate(metamodel);
 				}
 				
 			}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorDelegate.java
@@ -14,7 +14,9 @@ import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ISourceRange;
 import org.jboss.tools.common.validation.TempMarkerManager;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaApplication;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsApplication;
@@ -39,10 +41,16 @@ public class JaxrsMetamodelValidatorDelegate extends AbstractJaxrsElementValidat
 		JaxrsMetamodelValidator.deleteJaxrsMarkers(project);
 		metamodel.resetProblemLevel();
 		final List<IJaxrsApplication> allApplications = metamodel.getAllApplications();
+		final List<JaxrsJavaApplication> javaApplications = metamodel.getJavaApplications();
 		if (allApplications.isEmpty()) {
 			addProblem(JaxrsValidationMessages.APPLICATION_NO_OCCURRENCE_FOUND,
 					JaxrsPreferences.APPLICATION_NO_OCCURRENCE_FOUND, new String[0], metamodel);
-
+		} else if (javaApplications.size() > 1) {
+			for(JaxrsJavaApplication javaApplication: javaApplications) {
+				final ISourceRange javaNameRange = javaApplication.getJavaElement().getNameRange();
+				addProblem(JaxrsValidationMessages.APPLICATION_TOO_MANY_OCCURRENCES,
+						JaxrsPreferences.APPLICATION_TOO_MANY_OCCURRENCES, new String[0], javaNameRange, javaApplication);
+			}
 		}
 	}
 


### PR DESCRIPTION
Restored the missing call to the JaxrsMetamodelValidatorDelegate that performs cross-elements validation
Included two JUnit tests
