### PR TITLE
JBIDE-14988 - Force usage of JaxB 2.2 on master

### DIFF
--- a/plugins/org.jboss.tools.ws.wise.ui/.classpath
+++ b/plugins/org.jboss.tools.ws.wise.ui/.classpath
@@ -60,8 +60,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/xmlschema-core-2.0.3.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/xpp3_min-1.1.3.4.O.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/xstream-1.2.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jaxb-impl-2.2.5.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jaxb-xjc-2.2.5.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/wise-core-2.0.2.Final.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/wise-core-cxf-2.0.2.Final.jar"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/plugins/org.jboss.tools.ws.wise.ui/pom.xml
+++ b/plugins/org.jboss.tools.ws.wise.ui/pom.xml
@@ -21,6 +21,17 @@
       <artifactId>wise-core-cxf</artifactId>
       <version>2.0.2.Final</version>
     </dependency>
+    <!-- JBIDE-14988: explicit dependency on recent Jax-b -->
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-xjc</artifactId>
+      <version>2.2.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.5.1</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
These are the same changes (plus the .classpath change) that mistria did here: https://github.com/jbosstools/jbosstools-webservices/pull/56. Note that build.properties did not change because it was already correct on master.
