### PR TITLE
JBIDE-12690 No JAX-RS problems when importing a project that contains errors

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedBuildJob.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedBuildJob.java
@@ -59,9 +59,12 @@ public class JavaElementChangedBuildJob extends Job {
 			for(JavaElementDelta delta : affectedJavaElements) {
 				final IJavaProject javaProject = delta.getElement().getJavaProject();
 				final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(javaProject);
-				metamodel.processJavaElementChange(delta, progressMonitor);
-				if (progressMonitor.isCanceled()) {
-					return Status.CANCEL_STATUS;
+				// prevent NPE when opening a closed project (ie, there's no metamodel yet).
+				if(metamodel != null) {
+					metamodel.processJavaElementChange(delta, progressMonitor);
+					if (progressMonitor.isCanceled()) {
+						return Status.CANCEL_STATUS;
+					}
 				}
 			}
 		} catch (Throwable e) {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/MutexJobSchedulingRule.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/MutexJobSchedulingRule.java
@@ -12,6 +12,7 @@ package org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
 
 /**
  * Mutex Scheduling Rule to avoid concurrent JAX-RS Metamodel Build jobs on the same project.
@@ -41,7 +42,11 @@ public class MutexJobSchedulingRule implements ISchedulingRule {
 	 */
 	@Override
 	public boolean isConflicting(final ISchedulingRule otherRule) {
-		return (otherRule instanceof MutexJobSchedulingRule && ((MutexJobSchedulingRule)otherRule).getProject().equals(this.project));
+		final boolean conflict = otherRule instanceof MutexJobSchedulingRule && ((MutexJobSchedulingRule)otherRule).getProject().equals(this.project);
+		if(conflict) {
+			Logger.trace("Rule conflict between {} and {}", this, otherRule);
+		}
+		return conflict;
 	}
 
 

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidator.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidator.java
@@ -131,7 +131,9 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 					// validate at the metamodel level for cross-elements validation
 					validate(metamodel);
 				}
-				
+			} else {
+				Logger.debug("*** Validating full project {} because no file changed... ***", project.getName());
+				validateAll(project, validationHelper, context, manager, reporter);
 			}
 		} catch (CoreException e) {
 			Logger.error("Failed to validate changed files " + changedFiles + " in project " + project, e);
@@ -311,6 +313,14 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 
 	@Override
 	public IValidatingProjectTree getValidatingProjects(IProject project) {
+		try {
+			JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+			if(metamodel!=null) {
+				return metamodel.getValidatingProjectTree();
+			}
+		} catch (CoreException e) {
+			Logger.error(e.getMessage(), e);
+		}
 		return new SimpleValidatingProjectTree(project);
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/.project
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/.project
@@ -15,6 +15,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<!-- DO NOT MODIFY/REFORMAT -->
+		<!-- buildCommand><name>org.eclipse.wst.validation.validationbuilder</name><arguments></arguments></buildCommand -->
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/WorkbenchUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/WorkbenchUtils.java
@@ -11,6 +11,8 @@
 
 package org.jboss.tools.ws.jaxrs.core;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -880,10 +882,15 @@ public class WorkbenchUtils {
 	 * @throws CoreException
 	 * @throws IOException
 	 */
-	public static void replaceContent(IResource resource, String oldContent, String newContent) throws CoreException, IOException {
+	public static void replaceContent(final IResource resource, final String oldContent, final String newContent) throws CoreException, IOException {
+		// pre-condition: verify that resource exists 
+		assertThat(resource.exists(), is(true));
 		final IProject project = resource.getProject();
 		final IFile file = project.getFile(resource.getProjectRelativePath());
 		final String content = IOUtils.toString(file.getContents());
+		// pre-condition: verify that resource contains old content
+		assertThat(content.indexOf(oldContent), not(-1));
+		// operation
 		final String  modifiedContent = content.replace(oldContent, newContent);
 		file.delete(true, new NullProgressMonitor());
 		file.create(IOUtils.toInputStream(modifiedContent), true, null);

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/configuration/ProjectBuilderUtilsTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/configuration/ProjectBuilderUtilsTestCase.java
@@ -11,7 +11,17 @@
 
 package org.jboss.tools.ws.jaxrs.core.internal.configuration;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.core.resources.ICommand;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.jboss.tools.ws.jaxrs.core.AbstractCommonTestCase;
+import org.jboss.tools.ws.jaxrs.core.WorkbenchUtils;
 import org.jboss.tools.ws.jaxrs.core.configuration.ProjectBuilderUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,6 +31,30 @@ public class ProjectBuilderUtilsTestCase extends AbstractCommonTestCase {
 
 	private static String BUILDER_ID = "org.jboss.tools.ws.jaxrs.core.builder.JaxrsMetamodelBuilder";
 
+	/**
+	 * Returns an array containing the name of the {@link ICommand} configured for this project
+	 * 
+	 * @param project
+	 *            the project
+	 * @param builderId
+	 *            the builder ID
+	 * @return the index or -1 if not found
+	 * @throws CoreException
+	 *             in case of underlying exception
+	 */
+	private static String[] getCommandNames(final IProject project) throws CoreException {
+		IProjectDescription desc = project.getDescription();
+		ICommand[] commands = desc.getBuildSpec();
+		final String[] names = new String[commands.length];
+		for (int i = 0; i < commands.length; i++) {
+			names[i]  = commands[i].getBuilderName();
+		}
+		// not found
+		return names;
+	}
+	
+
+	
 	@Test
 	public void shouldVerifyProjectBuilderIsNotInstalled() throws Exception {
 		Assert.assertFalse("Wrong result",
@@ -52,7 +86,33 @@ public class ProjectBuilderUtilsTestCase extends AbstractCommonTestCase {
 	}
 
 	@Test
-	public void shouldInstallProjectFacetAndCheckPosition() throws Exception {
+	public void shouldInstallProjectFacetAndCheckPositionIsBeforeValidator() throws Exception {
+		// pre-conditions
+		ProjectBuilderUtils.uninstallProjectBuilder(javaProject.getProject(), BUILDER_ID);
+		Assert.assertFalse("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(javaProject.getProject(), BUILDER_ID));
+		final IResource dotProjectFile = project.findMember(".project");
+		// pre-conditions: activating the validation builder
+		WorkbenchUtils
+				.replaceContent(
+						dotProjectFile,
+						"<!-- buildCommand><name>org.eclipse.wst.validation.validationbuilder</name><arguments></arguments></buildCommand -->",
+						"<buildCommand><name>org.eclipse.wst.validation.validationbuilder</name><arguments></arguments></buildCommand>");
+		assertThat(getCommandNames(project).length, equalTo(3));
+		// operation
+		ProjectBuilderUtils.installProjectBuilder(javaProject.getProject(), BUILDER_ID);
+		// post-conditions
+		final int p = ProjectBuilderUtils.getBuilderPosition(project, BUILDER_ID);
+		assertThat(p, equalTo(2));
+		final String[] names = getCommandNames(project);
+		assertThat(names.length, equalTo(4));
+		for(int i = 0; i < names.length; i++) {
+			assertThat(names[i], notNullValue());
+		}
+	}
+
+	@Test
+	public void shouldInstallProjectFacetAndCheckPositionIsLast() throws Exception {
 		// pre-conditions
 		ProjectBuilderUtils.uninstallProjectBuilder(javaProject.getProject(), BUILDER_ID);
 		Assert.assertFalse("Wrong result",
@@ -61,7 +121,11 @@ public class ProjectBuilderUtilsTestCase extends AbstractCommonTestCase {
 		ProjectBuilderUtils.installProjectBuilder(javaProject.getProject(), BUILDER_ID);
 		// post-conditions
 		int p = ProjectBuilderUtils.getBuilderPosition(project, BUILDER_ID);
-		Assert.assertTrue("Wrong index" + p, p != -1);
-
+		assertThat(p, equalTo(2));
+		final String[] names = getCommandNames(project);
+		assertThat(names.length, equalTo(3));
+		for(int i = 0; i < names.length; i++) {
+			assertThat(names[i], notNullValue());
+		}
 	}
 }


### PR DESCRIPTION
Preventing some NPE
Taking care of having the metamodel build command inserted _before_ the validation command
Keeping the validation context in the JAX-RS Metamodel (via the ValidationContextTree) to hold
the context between validation calls.
