### PR TITLE
JBIDE-15031 - JAX-RS Metamodel builder called too many times during project build

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
@@ -84,7 +84,7 @@ public class UriPathTemplateCategory implements ITreeContentProvider {
 				Logger.debug("Displaying the 'Loading...' stub for project '{}' and launching a build", project.getName());
 				return new Object[] { new LoadingStub() };
 			} else {
-				launchLoadingMetamodelJob(this);
+				//launchLoadingMetamodelJob(this);
 				// return a stub object that says loading...
 				Logger.debug("Just displaying the 'Loading...' stub for project '{}'", project.getName());
 				return new Object[] { new LoadingStub() };


### PR DESCRIPTION
Do not launch a build job when the metamodel already exist and is being initialized.
