### PR TITLE
JBIDE-15039 - JAX-RS Problem decorator not shown on the Project Explorer node

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedBuildJob.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedBuildJob.java
@@ -53,6 +53,9 @@ public class JavaElementChangedBuildJob extends Job {
 			// scan and filter delta, retrieve a list of java changes
 			final List<JavaElementDelta> affectedJavaElements = new JavaElementDeltaScanner().scanAndFilterEvent(event,
 					new SubProgressMonitor(progressMonitor, SCALE));
+			if(affectedJavaElements.isEmpty()) {
+				Logger.debug("No relevant affected element to process");
+			}
 			if (progressMonitor.isCanceled()) {
 				return Status.CANCEL_STATUS;
 			}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
@@ -57,9 +57,11 @@ public abstract class JaxrsBaseElement implements IJaxrsElement {
 	 * 
 	 * @param problem
 	 *            level: the incoming new problem level.
+	 * @throws CoreException 
 	 */
 	public void setProblemLevel(final int problemLevel) {
 		this.problemLevel = Math.max(this.problemLevel, problemLevel);
+		metamodel.notifyProblemLevelChange(this);
 	}
 
 	/**

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/JaxrsElementDelta.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/JaxrsElementDelta.java
@@ -202,4 +202,5 @@ public class JaxrsElementDelta implements Comparable<JaxrsElementDelta> {
 		return elementKind.ordinal() - otherElementKind.ordinal();
 	}
 
+
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/JBossJaxrsUIPlugin.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/JBossJaxrsUIPlugin.java
@@ -19,11 +19,12 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
-import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.DecorationOverlayIcon;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.jboss.tools.ws.jaxrs.ui.internal.utils.Logger;
 import org.osgi.framework.BundleContext;
@@ -141,9 +142,9 @@ public class JBossJaxrsUIPlugin extends AbstractUIPlugin {
 		final ImageDescriptor baseImageDescriptor = ImageDescriptor.createFromURL(imageFileUrl);
 		switch (problemLevel) {
 		case IMarker.SEVERITY_ERROR:
-			return createDecoratedImageDescriptor(baseImageDescriptor, "org.eclipse.jface.fieldassist.IMG_DEC_FIELD_ERROR");
+			return createDecoratedImageDescriptor(baseImageDescriptor, ISharedImages.IMG_DEC_FIELD_ERROR);
 		case IMarker.SEVERITY_WARNING:
-			return createDecoratedImageDescriptor(baseImageDescriptor, "org.eclipse.jface.fieldassist.IMG_DEC_FIELD_WARNING");
+			return createDecoratedImageDescriptor(baseImageDescriptor, ISharedImages.IMG_DEC_FIELD_WARNING);
 
 		default:
 			return baseImageDescriptor;
@@ -160,7 +161,7 @@ public class JBossJaxrsUIPlugin extends AbstractUIPlugin {
 	 * which returns null for now.
 	 */
 	private ImageDescriptor createDecoratedImageDescriptor(final ImageDescriptor baseImageDescriptor, String decoratorId) {
-		final ImageDescriptor decoratorDescriptor = JFaceResources.getImageRegistry().getDescriptor(decoratorId);
+		final ImageDescriptor decoratorDescriptor = PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(decoratorId); 
 		final Image baseImage = baseImageDescriptor.createImage();
 		final DecorationOverlayIcon result = new DecorationOverlayIcon(baseImage, new ImageDescriptor[] { null, null, decoratorDescriptor, null, null },
 				new Point(16, 16));


### PR DESCRIPTION
Adding notification each time a JAX-RS element is validated so that it's UI element gets refreshed
Also 'update' the parent node element to show/hide the problem decorator
