### PR TITLE
JBIDE-15039 - JAX-RS Problem decorator not shown on the Project Explorer node

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsApplication.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsApplication.java
@@ -1,0 +1,32 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain;
+
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsApplication;
+
+/**
+ * Base class for JAX-RS Applications. Mostly justified for usage with generic types.
+ * @author xcoulon
+ *
+ */
+public abstract class JaxrsApplication extends JaxrsBaseElement implements IJaxrsApplication {
+
+	/**
+	 * Mandatory constructor.
+	 * @param metamodel
+	 */
+	public JaxrsApplication(JaxrsMetamodel metamodel) {
+		super(metamodel);
+	}
+
+	
+}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
@@ -61,7 +61,6 @@ public abstract class JaxrsBaseElement implements IJaxrsElement {
 	 */
 	public void setProblemLevel(final int problemLevel) {
 		this.problemLevel = Math.max(this.problemLevel, problemLevel);
-		metamodel.notifyProblemLevelChange(this);
 	}
 
 	/**

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpoint.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpoint.java
@@ -412,7 +412,6 @@ public class JaxrsEndpoint implements IJaxrsEndpoint {
 			level = Math.max(level, resourceMethod.getProblemLevel());
 		}
 		level = Math.max(level, httpMethod.getProblemLevel());
-		level = Math.max(level, metamodel.getProblemLevel());
 		if(application != null) {
 			level = Math.max(level, application.getProblemLevel());
 		}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsWebxmlApplication.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsWebxmlApplication.java
@@ -30,10 +30,15 @@ import org.jboss.tools.ws.jaxrs.core.internal.utils.WtpUtils;
 import org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname;
 import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementKind;
-import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsApplication;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
 
-public class JaxrsWebxmlApplication extends JaxrsBaseElement implements IJaxrsApplication {
+/**
+ * JAX-RS Application defined as part of a web deployment descriptor.
+ * 
+ * @author xcoulon
+ *
+ */
+public class JaxrsWebxmlApplication extends JaxrsApplication {
 
 	/**
 	 * Initialize the JaxrsWebxmlApplication builder with the given {@link IResource}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/AbstractValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/AbstractValidatorDelegate.java
@@ -1,0 +1,68 @@
+/******************************************************************************* 
+ * Copyright (c) 2012 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ISourceRange;
+import org.jboss.tools.common.validation.TempMarkerManager;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsBaseElement;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
+import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsStatus;
+
+/**
+ * Abstract validator delegate with bits of generics for better readability in subclasses
+ * 
+ * @author Xavier Coulon
+ *
+ */
+public abstract class AbstractValidatorDelegate<T extends IJaxrsStatus> {
+	
+	private final TempMarkerManager markerManager;
+	
+	public AbstractValidatorDelegate(final TempMarkerManager markerManager) {
+		this.markerManager = markerManager;
+	}
+	
+	abstract void validate(final T element) throws CoreException;
+
+	TempMarkerManager getMarkerManager() {
+		return markerManager;
+	}
+
+	public IMarker addProblem(final String message, final String preferenceKey, final String[] messageArguments, final JaxrsMetamodel metamodel) {
+		final IProject project = metamodel.getProject();
+		Logger.debug("Reporting problem '{}' on project '{}'", message, project.getName());
+		final IMarker marker = markerManager.addProblem(message, preferenceKey, messageArguments, 0, 0, project);
+		metamodel.setProblemLevel(marker.getAttribute(IMarker.SEVERITY, 0));
+		return marker;
+		
+	}
+	public IMarker addProblem(final String message, final String preferenceKey, final String[] messageArguments, final ISourceRange range, final JaxrsBaseElement element) {
+		final IResource resource = element.getResource();
+		Logger.debug("Reporting problem '{}' on resource '{}'", message, resource.getFullPath().toString());
+		final IMarker marker = markerManager.addProblem(message, preferenceKey, messageArguments, range.getLength(), range.getOffset(), resource);
+		element.setProblemLevel(marker.getAttribute(IMarker.SEVERITY, 0));
+		return marker;
+	}
+
+	public IMarker addProblem(final String message, final String preferenceKey, final String[] messageArguments, final ISourceRange range, final JaxrsBaseElement element, final int quickFixId) {
+		final IResource resource = element.getResource();
+		Logger.debug("Reporting problem '{}' on resource '{}'", message, resource.getFullPath().toString());
+		final IMarker marker = markerManager.addProblem(message, preferenceKey, messageArguments, range.getLength(), range.getOffset(), resource, quickFixId);
+		element.setProblemLevel(marker.getAttribute(IMarker.SEVERITY, 0));
+		return marker;
+	}
+
+}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorDelegate.java
@@ -35,8 +35,12 @@ public class JaxrsHttpMethodValidatorDelegate extends AbstractJaxrsElementValida
 		super(markerManager);
 	}
 
+	/**
+	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.
+	 * AbstractJaxrsElementValidatorDelegate#internalValidate(Object)
+	 */
 	@Override
-	public void validate(final JaxrsHttpMethod httpMethod) throws CoreException {
+	void internalValidate(final JaxrsHttpMethod httpMethod) throws CoreException {
 		JaxrsMetamodelValidator.deleteJaxrsMarkers(httpMethod);
 		httpMethod.resetProblemLevel();
 		Logger.debug("Validating element {}", httpMethod);

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsJavaApplicationValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsJavaApplicationValidatorDelegate.java
@@ -15,12 +15,9 @@ import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
 import org.jboss.tools.common.validation.TempMarkerManager;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaApplication;
-import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsWebxmlApplication;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
-import org.jboss.tools.ws.jaxrs.core.internal.utils.WtpUtils;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname;
-import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsApplication;
 import org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences;
 
 /**
@@ -29,28 +26,18 @@ import org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences;
  * @author Xavier Coulon
  * 
  */
-public class JaxrsApplicationValidatorDelegate extends AbstractJaxrsElementValidatorDelegate<IJaxrsApplication> {
+public class JaxrsJavaApplicationValidatorDelegate extends AbstractJaxrsElementValidatorDelegate<JaxrsJavaApplication> {
 
-	public JaxrsApplicationValidatorDelegate(final TempMarkerManager markerManager) {
+	public JaxrsJavaApplicationValidatorDelegate(final TempMarkerManager markerManager) {
 		super(markerManager);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * 
+	/**
 	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.
-	 * AbstractJaxrsElementValidatorDelegate#validate()
+	 * AbstractJaxrsElementValidatorDelegate#internalValidate(Object)
 	 */
 	@Override
-	public void validate(final IJaxrsApplication application) throws CoreException {
-		if (application.isJavaApplication()) {
-			validate((JaxrsJavaApplication) application);
-		} else {
-			validate((JaxrsWebxmlApplication) application);
-		}
-	}
-
-	public void validate(final JaxrsJavaApplication application) throws CoreException {
+	void internalValidate(final JaxrsJavaApplication application) throws CoreException {
 		Logger.debug("Validating element {}", application);
 		JaxrsMetamodelValidator.deleteJaxrsMarkers(application);
 		application.resetProblemLevel();
@@ -83,24 +70,6 @@ public class JaxrsApplicationValidatorDelegate extends AbstractJaxrsElementValid
 			}
 		}
 
-	}
-
-	public void validate(final JaxrsWebxmlApplication webxmlApplication) throws CoreException {
-		Logger.debug("Validating element {}", webxmlApplication);
-		JaxrsMetamodelValidator.deleteJaxrsMarkers(webxmlApplication);
-		webxmlApplication.resetProblemLevel();
-		if (webxmlApplication.getMetamodel().hasMultipleApplications()) {
-			ISourceRange webxmlNameRange = WtpUtils.getApplicationPathLocation(webxmlApplication.getResource(),
-					webxmlApplication.getJavaClassName());
-			if (webxmlNameRange == null) {
-				Logger.warn("Cannot add a problem marker: unable to locate '" + webxmlApplication.getJavaClassName()
-						+ "' in resource '" + webxmlApplication.getResource().getFullPath().toString() + "'. ");
-			} else {
-				addProblem(JaxrsValidationMessages.APPLICATION_TOO_MANY_OCCURRENCES,
-						JaxrsPreferences.APPLICATION_TOO_MANY_OCCURRENCES, new String[0], webxmlNameRange,
-						webxmlApplication);
-			}
-		}
 	}
 
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorDelegate.java
@@ -28,14 +28,14 @@ import org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences;
  * @author Xavier Coulon
  * 
  */
-public class JaxrsMetamodelValidatorDelegate extends AbstractJaxrsElementValidatorDelegate<JaxrsMetamodel> {
+public class JaxrsMetamodelValidatorDelegate extends AbstractValidatorDelegate<JaxrsMetamodel> {
 
 	public JaxrsMetamodelValidatorDelegate(final TempMarkerManager markerManager) {
 		super(markerManager);
 	}
 
 	@Override
-	public void validate(final JaxrsMetamodel metamodel) throws CoreException {
+	void validate(JaxrsMetamodel metamodel) throws CoreException {
 		Logger.debug("Validating element {}", metamodel);
 		final IProject project = metamodel.getProject();
 		JaxrsMetamodelValidator.deleteJaxrsMarkers(project);
@@ -53,5 +53,7 @@ public class JaxrsMetamodelValidatorDelegate extends AbstractJaxrsElementValidat
 			}
 		}
 	}
+
+	
 
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsProviderValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsProviderValidatorDelegate.java
@@ -58,10 +58,11 @@ public class JaxrsProviderValidatorDelegate extends AbstractJaxrsElementValidato
 	}
 
 	/**
-	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.AbstractJaxrsElementValidatorDelegate#validate()
+	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.
+	 * AbstractJaxrsElementValidatorDelegate#internalValidate(Object)
 	 */
 	@Override
-	public void validate(JaxrsProvider provider) throws CoreException {
+	void internalValidate(JaxrsProvider provider) throws CoreException {
 		Logger.debug("Validating element {}", provider);
 		try {
 			provider.resetProblemLevel();

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
@@ -56,8 +56,12 @@ public class JaxrsResourceMethodValidatorDelegate extends AbstractJaxrsElementVa
 		super(markerManager);
 	}
 
+	/**
+	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.
+	 * AbstractJaxrsElementValidatorDelegate#internalValidate(Object)
+	 */
 	@Override
-	public void validate(final JaxrsResourceMethod resourceMethod) throws JavaModelException {
+	void internalValidate(final JaxrsResourceMethod resourceMethod) throws JavaModelException {
 		Logger.debug("Validating element {}", resourceMethod);
 		resourceMethod.resetProblemLevel();
 		validatePublicModifierOnJavaMethod(resourceMethod);

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorDelegate.java
@@ -12,9 +12,9 @@ package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
 import org.eclipse.core.runtime.CoreException;
 import org.jboss.tools.common.validation.TempMarkerManager;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceMethod;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
-import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResourceMethod;
 
 /**
@@ -23,14 +23,18 @@ import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResourceMethod;
  * @author Xavier Coulon
  * 
  */
-public class JaxrsResourceValidatorDelegate extends AbstractJaxrsElementValidatorDelegate<IJaxrsResource> {
+public class JaxrsResourceValidatorDelegate extends AbstractJaxrsElementValidatorDelegate<JaxrsResource> {
 
 	public JaxrsResourceValidatorDelegate(final TempMarkerManager markerManager) {
 		super(markerManager);
 	}
 
+	/**
+	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.
+	 * AbstractJaxrsElementValidatorDelegate#internalValidate(Object)
+	 */
 	@Override
-	public void validate(final IJaxrsResource resource) throws CoreException {
+	void internalValidate(final JaxrsResource resource) throws CoreException {
 		Logger.debug("Validating element {}", resource);
 		JaxrsMetamodelValidator.deleteJaxrsMarkers(resource);
 		for(IJaxrsResourceMethod resourceMethod : resource.getAllMethods()) {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsWebxmlApplicationValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsWebxmlApplicationValidatorDelegate.java
@@ -1,0 +1,56 @@
+/******************************************************************************* 
+ * Copyright (c) 2012 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ISourceRange;
+import org.jboss.tools.common.validation.TempMarkerManager;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsWebxmlApplication;
+import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
+import org.jboss.tools.ws.jaxrs.core.internal.utils.WtpUtils;
+import org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences;
+
+/**
+ * Java-based JAX-RS Application validator
+ * 
+ * @author Xavier Coulon
+ * 
+ */
+public class JaxrsWebxmlApplicationValidatorDelegate extends AbstractJaxrsElementValidatorDelegate<JaxrsWebxmlApplication> {
+
+	public JaxrsWebxmlApplicationValidatorDelegate(final TempMarkerManager markerManager) {
+		super(markerManager);
+	}
+
+	/**
+	 * @see org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.
+	 * AbstractJaxrsElementValidatorDelegate#internalValidate(Object)
+	 */
+	@Override
+	void internalValidate(final JaxrsWebxmlApplication webxmlApplication) throws CoreException {
+		Logger.debug("Validating element {}", webxmlApplication);
+		JaxrsMetamodelValidator.deleteJaxrsMarkers(webxmlApplication);
+		webxmlApplication.resetProblemLevel();
+		if (webxmlApplication.getMetamodel().hasMultipleApplications()) {
+			ISourceRange webxmlNameRange = WtpUtils.getApplicationPathLocation(webxmlApplication.getResource(),
+					webxmlApplication.getJavaClassName());
+			if (webxmlNameRange == null) {
+				Logger.warn("Cannot add a problem marker: unable to locate '" + webxmlApplication.getJavaClassName()
+						+ "' in resource '" + webxmlApplication.getResource().getFullPath().toString() + "'. ");
+			} else {
+				addProblem(JaxrsValidationMessages.APPLICATION_TOO_MANY_OCCURRENCES,
+						JaxrsPreferences.APPLICATION_TOO_MANY_OCCURRENCES, new String[0], webxmlNameRange,
+						webxmlApplication);
+			}
+		}
+	}
+
+}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsElement.java
@@ -10,7 +10,6 @@
  ******************************************************************************/
 package org.jboss.tools.ws.jaxrs.core.metamodel.domain;
 
-import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 
 /**
@@ -19,17 +18,11 @@ import org.eclipse.core.resources.IResource;
  * @author Xavier Coulon
  * 
  */
-public interface IJaxrsElement {
+public interface IJaxrsElement extends IJaxrsStatus {
 
 	public abstract IJaxrsMetamodel getMetamodel();
 
 	public abstract EnumElementKind getElementKind();
-
-	/**
-	 * @return the highest level problem this resource method has.
-	 * @see {@link IMarker} for severity levels and values.
-	 */
-	abstract int getProblemLevel();
 
 	/**
 	 * The unique identifier for the JAX-RS Element is:

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsEndpointChangedListener.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsEndpointChangedListener.java
@@ -12,6 +12,7 @@
 package org.jboss.tools.ws.jaxrs.core.metamodel.domain;
 
 
+
 /**
  * Interface to get notified of the JAX-RS Endpoint changes.
  * 
@@ -28,5 +29,17 @@ public interface IJaxrsEndpointChangedListener {
 	 * @param delta
 	 */
 	public void notifyEndpointChanged(JaxrsEndpointDelta delta);
+
+	/**
+	 * Method called when the problem level of the given {@link IJaxrsEndpoint} changed
+	 * @param affectedEndpoint the endpoint whose problem level changed
+	 */
+	public void notifyEndpointProblemLevelChanged(IJaxrsEndpoint affectedEndpoint);
+
+	/**
+	 * Method called when the problem level of the given {@link IJaxrsMetamodel} changed
+	 * @param metamodel the metamodel whose problem level changed
+	 */
+	public void notifyMetamodelProblemLevelChanged(IJaxrsMetamodel jaxrsMetamodel);
 
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsMetamodel.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaElement;
 
-public interface IJaxrsMetamodel {
+public interface IJaxrsMetamodel extends IJaxrsStatus {
 
 	/**
 	 * Returns <code>true</code> if the JAX-RS Metamodel is being initialized, false if it has already been initialized.
@@ -33,10 +33,16 @@ public interface IJaxrsMetamodel {
 	 *            the Java Element
 	 * @return the JAX-RS Element or null if none matches.
 	 */
-	public abstract IJaxrsElement findElement(final IJavaElement javaElement);
+	public abstract IJaxrsStatus findElement(final IJavaElement javaElement);
 	
 	public abstract IProject getProject();
 
+	/**
+	 * Adds the given {@link IJaxrsEndpointChangedListener} listener to the metamodel. Has no effect if 
+	 * the same listener has already been registered.
+	 * 
+	 * @param listener
+	 */
 	public abstract void addListener(IJaxrsEndpointChangedListener listener);
 
 	public void removeListener(IJaxrsEndpointChangedListener listener);

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsStatus.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/metamodel/domain/IJaxrsStatus.java
@@ -1,0 +1,13 @@
+package org.jboss.tools.ws.jaxrs.core.metamodel.domain;
+
+import org.eclipse.core.resources.IMarker;
+
+public interface IJaxrsStatus {
+
+	/**
+	 * @return the highest level problem this resource method has.
+	 * @see {@link IMarker} for severity levels and values.
+	 */
+	public abstract int getProblemLevel();
+
+}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriMappingsLabelProvider.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriMappingsLabelProvider.java
@@ -36,7 +36,7 @@ public class UriMappingsLabelProvider implements IStyledLabelProvider, ILabelPro
 	@Override
 	public Image getImage(Object element) {
 		if (element instanceof UriPathTemplateCategory) {
-			return JBossJaxrsUIPlugin.getDefault().getImage("restful_web_services.gif", ((UriPathTemplateCategory) element).getProblemLevel());
+ 			return JBossJaxrsUIPlugin.getDefault().getImage("restful_web_services.gif", ((UriPathTemplateCategory) element).getProblemLevel());
 		} else if (element instanceof UriPathTemplateElement) {
 			return JBossJaxrsUIPlugin.getDefault().getImage("url_mapping.gif", ((UriPathTemplateElement) element).getProblemLevel());
 		} else if (element instanceof UriPathTemplateMediaTypeMappingElement) {

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
@@ -56,7 +56,6 @@ public class UriPathTemplateCategory implements ITreeContentProvider {
 		try {
 			final IJaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
 			if (metamodel != null && !metamodel.isInitializing()) {
-				metamodel.addListener(parent);
 				final Collection<IJaxrsEndpoint> endpoints = metamodel.getAllEndpoints();
 				Logger.debug("UriPathTemplateCatogory contains {} endpoints", endpoints.size());
 				List<UriPathTemplateElement> uriPathTemplateElements = new ArrayList<UriPathTemplateElement>();

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/AbstractCommonTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/AbstractCommonTestCase.java
@@ -52,7 +52,9 @@ import org.jboss.tools.ws.jaxrs.core.jdt.CompilationUnitsRepository;
 import org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname;
 import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsElementChangedListener;
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsEndpoint;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsEndpointChangedListener;
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResourceMethod;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsEndpointDelta;
@@ -95,6 +97,10 @@ public abstract class AbstractCommonTestCase implements IJaxrsElementChangedList
 	protected List<JaxrsElementDelta> elementChanges = null;
 	
 	protected List<JaxrsEndpointDelta> endpointChanges = null;
+	
+	protected List<IJaxrsEndpoint> endpointProblemLevelChanges = null;
+
+	protected List<IJaxrsMetamodel> metamodelProblemLevelChanges = null;
 	
 	public final static String DEFAULT_SAMPLE_PROJECT_NAME = WorkbenchUtils
 			.retrieveSampleProjectName(AbstractCommonTestCase.class);
@@ -166,6 +172,8 @@ public abstract class AbstractCommonTestCase implements IJaxrsElementChangedList
 			metamodel = JaxrsMetamodel.create(javaProject);
 			this.elementChanges = new ArrayList<JaxrsElementDelta>();
 			this.endpointChanges = new ArrayList<JaxrsEndpointDelta>();
+			this.endpointProblemLevelChanges = new ArrayList<IJaxrsEndpoint>();
+			this.metamodelProblemLevelChanges = new ArrayList<IJaxrsMetamodel>();
 			metamodel.addListener((IJaxrsElementChangedListener)this);
 			metamodel.addListener((IJaxrsEndpointChangedListener)this);
 		} finally {
@@ -196,6 +204,13 @@ public abstract class AbstractCommonTestCase implements IJaxrsElementChangedList
 			metamodel.removeListener((IJaxrsEndpointChangedListener)this);
 		}
 	}
+	
+	void resetProblemLevelChangeNotifications() {
+		this.endpointProblemLevelChanges.clear();
+		this.metamodelProblemLevelChanges.clear();
+	}
+
+	
 	protected IType resolveType(String typeName) throws CoreException {
 		return JdtUtils.resolveType(typeName, javaProject, new NullProgressMonitor());
 	}
@@ -402,5 +417,19 @@ public abstract class AbstractCommonTestCase implements IJaxrsElementChangedList
 	public void notifyEndpointChanged(final JaxrsEndpointDelta delta) {
 		endpointChanges.add(delta);
 	}
+
+	@Override
+	public void notifyEndpointProblemLevelChanged(IJaxrsEndpoint endpoint) {
+		endpointProblemLevelChanges.add(endpoint);
+		
+	}
+
+	@Override
+	public void notifyMetamodelProblemLevelChanged(IJaxrsMetamodel metamodel) {
+		metamodelProblemLevelChanges.add(metamodel);
+		
+	}
+	
+	
 
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorTestCase.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
 import static org.jboss.tools.ws.jaxrs.core.WorkbenchUtils.getAnnotation;
@@ -75,6 +76,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		final JaxrsBaseElement httpMethod = (JaxrsBaseElement) metamodel.findElement(fooType);
 		assertThat(findJaxrsMarkers(httpMethod).length, equalTo(0));
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -83,7 +85,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
-
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
 	}
 
 	@Test
@@ -94,11 +96,13 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		//metamodel.add(httpMethod);
 		assertThat(findJaxrsMarkers(httpMethod).length, equalTo(0));
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(httpMethod).length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
 	}
 
 	@Test
@@ -109,6 +113,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		final Annotation httpMethodAnnotation = httpMethod.getAnnotation(HTTP_METHOD.qualifiedName);
 		httpMethod.addOrUpdateAnnotation(createAnnotation(httpMethodAnnotation, new String()));
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -119,6 +124,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -130,6 +137,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.addOrUpdateAnnotation(createAnnotation(httpMethodAnnotation, (String) null));
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@HttpMethod(\"FOO\")", "@HttpMethod", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -140,6 +148,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -151,6 +161,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.removeAnnotation(targetAnnotation.getJavaAnnotation());
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@Target(value=ElementType.METHOD)", "", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -161,6 +172,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -173,6 +186,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.addOrUpdateAnnotation(createAnnotation(targetAnnotation, (String) null));
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@Target(value=ElementType.METHOD)", "@Target", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -183,6 +197,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -195,6 +211,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.addOrUpdateAnnotation(createAnnotation(targetAnnotation, "FOO"));
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@Target(value=ElementType.METHOD)", "@Target(value=ElementType.FIELD)", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -205,6 +222,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -216,6 +235,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.removeAnnotation(targetAnnotation.getJavaAnnotation());
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@Retention(value=RetentionPolicy.RUNTIME)", "", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -226,6 +246,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 	
 	@Test
@@ -238,6 +260,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.addOrUpdateAnnotation(createAnnotation(retentionAnnotation, (String)null));
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@Retention(value=RetentionPolicy.RUNTIME)", "@Retention", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -248,6 +271,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 	
 	@Test
@@ -260,6 +285,7 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		httpMethod.addOrUpdateAnnotation(createAnnotation(retentionAnnotation, "FOO"));
 		WorkbenchUtils.replaceFirstOccurrenceOfCode(fooType.getCompilationUnit(), "@Retention(value=RetentionPolicy.RUNTIME)", "@Retention(value=RetentionPolicy.SOURCE)", true);
 		deleteJaxrsMarkers(httpMethod);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(httpMethod.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -270,6 +296,8 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
 			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorTestCase.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.deleteJaxrsMarkers;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.findJaxrsMarkers;
@@ -66,6 +67,7 @@ public class JaxrsMetamodelValidatorTestCase extends AbstractMetamodelBuilderTes
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(project);
 		assertThat(markers.length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
 	}
 	
 	

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsProviderValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsProviderValidatorTestCase.java
@@ -79,6 +79,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IJaxrsProvider provider = metamodel.findProvider(providerType);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -89,7 +90,6 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 			LOGGER.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
 					marker.getAttribute(IMarker.MESSAGE));
 		}
-		assertThat(markers.length, equalTo(0));
 	}
 
 	@Test
@@ -105,6 +105,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 						false);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -115,7 +116,6 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 			LOGGER.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
 					marker.getAttribute(IMarker.MESSAGE));
 		}
-		assertThat(markers.length, equalTo(0));
 	}
 
 	@Test
@@ -129,6 +129,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 				false);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -155,6 +156,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 						false);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -181,6 +183,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 						false);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -207,6 +210,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 						false);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -233,6 +237,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 				false);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -260,6 +265,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IJaxrsProvider otherProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		removeAllElementsExcept(provider, otherProvider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
 				(IFile) otherProvider.getResource());
@@ -288,6 +294,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IJaxrsProvider otherProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		removeAllElementsExcept(provider, otherProvider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
 				(IFile) otherProvider.getResource());
@@ -316,6 +323,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IJaxrsProvider otherProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		removeAllElementsExcept(provider, otherProvider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
 				(IFile) otherProvider.getResource());
@@ -345,6 +353,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IJaxrsProvider otherProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		removeAllElementsExcept(provider, otherProvider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
 				(IFile) otherProvider.getResource());
@@ -368,6 +377,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		provider.removeAnnotation(providerAnnotation.getJavaAnnotation());
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -390,6 +400,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
@@ -412,6 +423,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validateAll(project, validationHelper, context, validatorManager, reporter);
 		// validation
@@ -432,6 +444,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType);
 		removeAllElementsExcept(provider);
 		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validateAll(project, validationHelper, context, validatorManager, reporter);
 		// validation

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorTestCase.java
@@ -10,8 +10,8 @@
  ******************************************************************************/
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.deleteJaxrsMarkers;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.findJaxrsMarkers;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.hasPreferenceKey;
@@ -75,12 +75,14 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
 		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
 				context, validatorManager, reporter);
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(customerResource);
 		assertThat(markers.length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
 	}
 
 	@Test
@@ -89,6 +91,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IType barJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.BarResource");
 		final JaxrsResource barResource = metamodel.findResource(barJavaType);
 		deleteJaxrsMarkers(barResource);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(barResource.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -98,6 +101,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 			LOGGER.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER), marker.getAttribute(IMarker.MESSAGE));
 		}
 		assertThat(markers.length, equalTo(8));
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 	
 	
@@ -108,6 +113,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IType barJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.BazResource");
 		final JaxrsResource barResource = (JaxrsResource) metamodel.findElement(barJavaType);
 		deleteJaxrsMarkers(barResource);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(barResource.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -137,6 +143,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 				fail("Unexpected method " + entry.getKey());
 			}
 		}
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 	
 	@Test
@@ -147,6 +155,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final List<IJaxrsElement> elements = JaxrsElementFactory.createElements(compilationUnit.findPrimaryType(), JdtUtils.parse(compilationUnit, null), metamodel, new NullProgressMonitor());
 		final JaxrsResource resource = (JaxrsResource) elements.get(0); 
 		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -154,6 +163,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final IMarker[] markers = findJaxrsMarkers(resource);
 		// verification
 		assertThat(markers.length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
 	}
 
 	@Test
@@ -166,6 +176,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsResource resource = (JaxrsResource) elements.get(0); 
 		//metamodel.add(resource);
 		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
 		// operation
 		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -174,6 +185,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		// verification
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers[0].getAttribute(IMarker.LINE_NUMBER, 0), equalTo(14));
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -186,6 +199,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsResource resource = (JaxrsResource) elements.get(0); 
 		//metamodel.add(resource);
 		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
 		// operation: remove the @PathParam, so that some @Path value has no counterpart
 		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -197,6 +211,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		assertThat(marker.getAttribute(IMarker.SEVERITY, 0), equalTo(IMarker.SEVERITY_WARNING));
 		assertThat(marker.getAttribute(IMarker.LINE_NUMBER, 0), equalTo(9));
 		assertThat(marker.getAttribute(IMarker.CHAR_END, 0) - marker.getAttribute(IMarker.CHAR_START, 0), equalTo(6));
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -209,6 +225,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsResource resource = (JaxrsResource) elements.get(0); 
 		//metamodel.add(resource);
 		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
 		// operation: remove the @PathParam, so that some @Path value has no counterpart
 		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -220,6 +237,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		assertThat(marker.getAttribute(IMarker.SEVERITY, 0), equalTo(IMarker.SEVERITY_WARNING));
 		assertThat(marker.getAttribute(IMarker.LINE_NUMBER, 0), equalTo(13));
 		assertThat(marker.getAttribute(IMarker.CHAR_END, 0) - marker.getAttribute(IMarker.CHAR_START, 0), equalTo(26));
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
 	@Test
@@ -233,6 +252,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsResource resource = (JaxrsResource) elements.get(0); 
 		//metamodel.add(resource);
 		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
 		// operation: remove the @PathParam, so that some @Path value has no counterpart
 		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -244,6 +264,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		assertThat(marker.getAttribute(IMarker.SEVERITY, 0), equalTo(IMarker.SEVERITY_WARNING));
 		assertThat(marker.getAttribute(IMarker.LINE_NUMBER, 0), equalTo(13));
 		assertThat(marker.getAttribute(IMarker.CHAR_END, 0) - marker.getAttribute(IMarker.CHAR_START, 0), equalTo(28));
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 	
 	@Test
@@ -256,6 +278,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		final JaxrsResource resource = (JaxrsResource) elements.get(0); 
 		//metamodel.add(resource);
 		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
 		// operation: remove the @PathParam, so that some @Path value has no counterpart
 		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper, context,
 				validatorManager, reporter);
@@ -267,6 +290,8 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		assertThat(marker.getAttribute(IMarker.SEVERITY, 0), equalTo(IMarker.SEVERITY_ERROR));
 		assertThat(marker.getAttribute(IMarker.LINE_NUMBER, 0), equalTo(14));
 		assertThat(marker.getAttribute(IMarker.CHAR_END, 0) - marker.getAttribute(IMarker.CHAR_START, 0), equalTo(4));
+		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 	
 	@Test

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/MarkerUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/MarkerUtils.java
@@ -94,6 +94,7 @@ public class MarkerUtils {
 	}
 
 	/**
+	 * Reset JAX-RS Markers
 	 * @param element
 	 * @throws CoreException
 	 */


### PR DESCRIPTION
Main refactoring/changes in this PR consist in:
- compare the problem level of each JAX-RS element before vs after the validation, and
  in case of change, notify the metamodel. The metamodel will look for all affected Endpoints and
  send 'problem level change' notification to the listeners (here, the UI). In turn, the UI will _update_
  the associated node (update -> no refresh for sub nodes) to get a proper image decorator.
- same logix with the metamodel itself, except that the public problem level includes the problem level of the
  JAX-RS elements, which means that the 'JAX-RS Web Services' node now reflects the whole Metamodel and thus, displays the
  global problem level.
  This new UI refresh strategy also reduces the number of times refresh occurred (there's now a single refresh per affected element, even
  if this element has multiple problems).
- also fixed a problem where the UI listener would only be registered once the "JAX-RS Web Services" node was expended
