### PR TITLE
 	JBIDE-15508 - Incorrect problem marker when refactoring a custom Qualifier

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsHttpMethod.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsHttpMethod.java
@@ -172,7 +172,9 @@ public class JaxrsHttpMethod extends JaxrsJavaElement<IType> implements IJaxrsHt
 			}
 			annotations = JdtUtils.resolveAnnotations(javaType, ast, HTTP_METHOD.qualifiedName, TARGET.qualifiedName,
 					RETENTION.qualifiedName);
-			if (annotations == null || annotations.isEmpty()) {
+			// Element *MUST* at least have the @HttpMethod annotation to be an HTTP Method.
+			// Problems will be reported by validation if other annotations are missing.
+			if (annotations == null || annotations.isEmpty() || !annotations.containsKey(HTTP_METHOD.qualifiedName)) {
 				return null;
 			}
 			final JaxrsHttpMethod httpMethod = new JaxrsHttpMethod(this);

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/CustomCDIQualifier.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/CustomCDIQualifier.java
@@ -1,0 +1,14 @@
+package org.jboss.tools.ws.jaxrs.sample.services;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.HttpMethod;
+
+@Retention(value=RetentionPolicy.RUNTIME)
+@Target(value=ElementType.FIELD)
+public @interface CustomCDIQualifier {
+
+}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsElementFactoryTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsElementFactoryTestCase.java
@@ -128,6 +128,17 @@ public class JaxrsElementFactoryTestCase extends AbstractCommonTestCase {
 	}
 
 	@Test
+	public void shouldNotCreateHttpMethodFromType() throws CoreException {
+		// pre-conditions
+		final IType type = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomCDIQualifier");
+		// operation
+		final List<IJaxrsElement> elements = JaxrsElementFactory.createElements(type,
+				JdtUtils.parse(type, progressMonitor), metamodel, new NullProgressMonitor());
+		// verifications
+		assertThat(elements.size(), equalTo(0));
+	}
+
+	@Test
 	public void shouldNotCreateElementFromOtherType() throws CoreException {
 		// pre-conditions
 		final IType type = getType("org.jboss.tools.ws.jaxrs.sample.domain.Customer");

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsHttpMethodValidatorTestCase.java
@@ -300,4 +300,28 @@ public class JaxrsHttpMethodValidatorTestCase extends AbstractMetamodelBuilderTe
 		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
+
+	/**
+	 * @see 
+	 * @throws CoreException
+	 * @throws ValidationException
+	 */
+	@Test
+	public void shouldNotReportProblemWhenRefactoringUnrelatedAnnotation() throws CoreException,
+	ValidationException {
+		// preconditions
+		final IType customQualifierType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomCDIQualifier");
+		assertThat(customQualifierType.exists(), is(true));
+		resetElementChangesNotifications();
+		// operations: rename the Java type and attempt to create an HttpMethod and validate its underlying resource.
+		customQualifierType.rename("FOOBAR", true, new NullProgressMonitor());
+		final IType foobarType = getType("org.jboss.tools.ws.jaxrs.sample.services.FOOBAR");
+		createHttpMethod(foobarType);
+		new JaxrsMetamodelValidator().validate(toSet(foobarType.getResource()), project, validationHelper, context,
+				validatorManager, reporter);
+		// validation
+		final IMarker[] markers = foobarType.getResource().findMarkers(JaxrsValidationConstants.JAXRS_PROBLEM_TYPE, false, IResource.DEPTH_INFINITE);
+		assertThat(markers.length, equalTo(0));
+	}
+
 }


### PR DESCRIPTION
Initial problem was that _any_ annotation would be taken as a JAX-RS HTTP Method,
which was über wrong.
Added tests cases to verify.
