### PR TITLE
JBIDE-15599 - Changes on a subresource locator fields are not propagated to the JAX-RS Explorer

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -321,7 +321,7 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 			return null;
 		}
 		final JaxrsMetamodel metamodel = new JaxrsMetamodel(javaProject);
-		Logger.debug("JAX-RS Metamodel created for project " + javaProject.getElementName());
+		Logger.debug("JAX-RS Metamodel created for project {}", javaProject.getElementName());
 		javaProject.getProject().setSessionProperty(METAMODEL_QUALIFIED_NAME, metamodel);
 		return metamodel;
 	}
@@ -383,6 +383,7 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	@Override
 	public void addListener(final IJaxrsEndpointChangedListener listener) {
 		if(!endpointChangedListeners.contains(listener)) { 
+			Logger.debug("*** Registering EndpointChangedListener for project {} ***", javaProject.getElementName());
 			this.endpointChangedListeners.add(listener);
 		}
 	}
@@ -427,12 +428,14 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	 *            no change occurred)
 	 */
 	private void notifyListeners(final IJaxrsEndpoint endpoint, final int deltaKind) {
-		if (endpoint != null) {
+		if (endpoint != null && !endpointChangedListeners.isEmpty()) {
 			JaxrsEndpointDelta delta = new JaxrsEndpointDelta(endpoint, deltaKind);
-			Logger.trace("Notify elementChangedListeners after {}", delta);
+			Logger.trace("Notify project '{}' elementChangedListeners after {}", javaProject.getElementName(), delta);
 			for (IJaxrsEndpointChangedListener listener : endpointChangedListeners) {
 				listener.notifyEndpointChanged(delta);
 			}
+		} else if(endpointChangedListeners.isEmpty()) {
+			Logger.debug("*** No Listener for project '{}' to notify after endpoint changes: {} (change={}) ***", javaProject.getElementName(), endpoint, deltaKind);
 		}
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriMappingsContentProvider.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriMappingsContentProvider.java
@@ -67,8 +67,10 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 			final IJaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
 			// let's make sure this listener is registered
 			if (metamodel != null) {
-				// metamode.addListener() avoids duplicate entries
+				// metamodel.addListener() avoids duplicate entries
 				metamodel.addListener(this);
+			} else {
+				Logger.debug("*** No JAX-RS Metamodel available for project '{}' yet :-( ***", project.getName());
 			}
 			if (!uriPathTemplateCategories.containsKey(project)) {
 				UriPathTemplateCategory uriPathTemplateCategory = new UriPathTemplateCategory(this, project);
@@ -98,7 +100,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 			Logger.trace("Element {} has children: {}", element, hasChildren);
 			return hasChildren;
 		}
-		Logger.debug("Element {} has not children", element);
+		Logger.debug("Element '{}' has not children", element);
 		return false;
 	}
 
@@ -115,7 +117,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 					final IJaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
 					metamodel.removeListener(this);
 				} catch (CoreException e) {
-					Logger.error("Failed to remove listener on JAX-RS Metamodel", e);
+					Logger.error("Failed to remove listener on JAX-RS Metamodel '" + project.getName() + "'", e);
 				}
 			}
 		}
@@ -151,7 +153,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 		final UriPathTemplateCategory uriPathTemplateCategory = uriPathTemplateCategories.get(project);
 		final UriPathTemplateElement target = uriPathTemplateCategory.getUriPathTemplateElement(endpoint);
 		if(target != null) {
-			Logger.debug("Refreshing navigator view at level: {}", target.getClass().getName());
+			Logger.debug("Refreshing navigator view at level: '{}'", target.getClass().getName());
 			// this piece of code must run in an async manner to avoid reentrant
 			// call while viewer is busy.
 			updateContent(target);
@@ -166,7 +168,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 		final IProject project= metamodel.getProject();
 		if (uriPathTemplateCategories != null) {
 			if (!uriPathTemplateCategories.containsKey(project)) {
-				Logger.debug("Adding a UriPathTemplateCategory for project {} (case #1)", project.getName());
+				Logger.debug("Adding a UriPathTemplateCategory for project '{}' (case #1)", project.getName());
 				UriPathTemplateCategory uriPathTemplateCategory = new UriPathTemplateCategory(this, project);
 				uriPathTemplateCategories.put(project, uriPathTemplateCategory);
 				refreshContent(uriPathTemplateCategories.get(project));
@@ -184,7 +186,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 	public void refreshContent(final IProject project) {
 		if (uriPathTemplateCategories != null) {
 			if (!uriPathTemplateCategories.containsKey(project)) {
-				Logger.debug("Adding a UriPathTemplateCategory for project {} (case #1)", project.getName());
+				Logger.debug("Adding a UriPathTemplateCategory for project '{}' (case #1)", project.getName());
 				UriPathTemplateCategory uriPathTemplateCategory = new UriPathTemplateCategory(this, project);
 				uriPathTemplateCategories.put(project, uriPathTemplateCategory);
 			}
@@ -211,7 +213,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 		final UriPathTemplateElement target = uriPathTemplateCategory.getUriPathTemplateElement(endpoint);
 		// during initialization, UI may not be available yet.
 		if(target != null) {
-			Logger.debug("Refreshing navigator view at level: {}", target.getClass().getName());
+			Logger.debug("Refreshing navigator view at level: '{}'", target.getClass().getName());
 			// this piece of code must run in an async manner to avoid reentrant
 			// call while viewer is busy.
 			refreshContent(target);
@@ -233,7 +235,7 @@ public class UriMappingsContentProvider implements ITreeContentProvider, IJaxrsE
 			public void run() {
 				if (viewer != null) {
 					TreePath[] treePaths = viewer.getExpandedTreePaths();
-					Logger.debug("*** Refreshing the viewer at target level: {} (viewer busy: {}) ***", target,
+					Logger.debug("*** Refreshing the viewer at target level: '{}' (viewer busy: {}) ***", target,
 							viewer.isBusy());
 					viewer.refresh(target, true);
 					viewer.setExpandedTreePaths(treePaths);


### PR DESCRIPTION
Registered the URI Mappings Content Provider (in the UI) when the JAX-RS Web Services node is
expanded. This avoids the case where in some circumstances, the JAX-RS metamodel would have no
listener to notify when JAX-RS endpoints changed.

Also edited the log messages for sake of readability
