### PR TITLE
JBIDE-15428 - No JAX-RS problems when importing a project that contains HTTPMethod annotation without @Target and @Retention

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedBuildJob.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedBuildJob.java
@@ -12,6 +12,7 @@ package org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder;
 
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.JaxrsMetamodelBuilder.SCALE;
 
+import java.util.Date;
 import java.util.List;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -44,6 +45,7 @@ public class JavaElementChangedBuildJob extends Job {
 	
 	@Override
 	protected IStatus run(final IProgressMonitor progressMonitor) {
+		final long startTime = new Date().getTime();
 		IJavaElement element = null;
 		try {
 			progressMonitor.beginTask("Building JAX-RS Metamodel", 3 * SCALE);
@@ -73,11 +75,15 @@ public class JavaElementChangedBuildJob extends Job {
 						if (progressMonitor.isCanceled()) {
 							return Status.CANCEL_STATUS;
 						}
-						metamodel.setBuildStatus(Status.OK_STATUS);
 					} catch(Throwable e) {
 						final IStatus status = Logger.error("Failed to build or refresh the JAX-RS metamodel", e);
 						metamodel.setBuildStatus(status);
 						return status;
+					} finally {
+						Logger.debug(
+								"JAX-RS Metamodel for project '{}' now has {} HttpMethods, {} Resources and {} Endpoints.",
+								javaProject.getElementName(), metamodel.findAllHttpMethods().size(),
+								metamodel.getAllResources().size(), metamodel.getAllEndpoints().size());
 					}
 				}
 			}
@@ -89,6 +95,11 @@ public class JavaElementChangedBuildJob extends Job {
 			}
 		} finally {
 			progressMonitor.done();
+			long endTime = new Date().getTime();
+			if (Logger.isDebugEnabled()) {
+				Logger.debug("Java element changes processed in {} ms.", (endTime - startTime));
+			}
+			
 		}
 		return Status.OK_STATUS;
 	}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDelta.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDelta.java
@@ -62,15 +62,13 @@ public class JavaElementDelta extends EventObject {
 	 * 
 	 * @param element
 	 *            The java element that changed.
+	 * @param deltaKind
+	 *            The kind of change (ADDED, CHANGED, REMOVED).
+	 * @param eventType
+	 *            The type of event (POST_CHANGE or POST_RECONCILE).
 	 * @param compilationUnitAST
 	 *            The associated compilation unit AST (or null if it does not
 	 *            apply to the given element)
-	 * @param elementType
-	 *            The (detailed) Java Element kind.
-	 * @param deltaKind
-	 *            The kind of change.
-	 * @param compilationUnitAST
-	 *            the associated compilation unit AST
 	 * @param flags
 	 *            the detailed kind of change.
 	 * @see IJavaElementDelta for element change kind values.

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilter.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilter.java
@@ -21,7 +21,7 @@ import static org.eclipse.jdt.core.IJavaElement.PACKAGE_FRAGMENT_ROOT;
 import static org.eclipse.jdt.core.IJavaElement.TYPE;
 import static org.eclipse.jdt.core.IJavaElementDelta.ADDED;
 import static org.eclipse.jdt.core.IJavaElementDelta.CHANGED;
-import static org.eclipse.jdt.core.IJavaElementDelta.F_ADDED_TO_CLASSPATH;
+import static org.eclipse.jdt.core.IJavaElementDelta.*;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_AST_AFFECTED;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_CONTENT;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_FINE_GRAINED;

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/ResourceChangedListener.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/ResourceChangedListener.java
@@ -14,6 +14,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
+import org.eclipse.core.runtime.CoreException;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelLocator;
@@ -51,18 +52,18 @@ public class ResourceChangedListener implements IResourceChangeListener {
 		if(!active) {
 			return;
 		}
-		try {
-			if (event.getType() == IResourceChangeEvent.PRE_CLOSE && event.getResource() != null
-					&& event.getResource().getType() == IResource.PROJECT) {
-				final IProject project = (IProject) event.getResource();
-				final JaxrsMetamodel jaxrsMetamodel = JaxrsMetamodelLocator.get(project);
-				if (jaxrsMetamodel != null) {
+		if (event.getType() == IResourceChangeEvent.PRE_CLOSE && event.getResource() != null
+				&& event.getResource().getType() == IResource.PROJECT) {
+			final IProject project = (IProject) event.getResource();
+			try {
+				final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+				if (metamodel != null) {
 					Logger.debug("Removing JAX-RS Metamodel before closing project " + project.getName());
-					jaxrsMetamodel.remove();
+					metamodel.remove();
 				}
+			} catch (CoreException e) {
+				Logger.error("Error while removing JAX-RS Metamodel", e);
 			}
-		} catch (Exception e) {
-			Logger.error("Error while removing JAX-RS Metamodel", e);
 		}
 
 	}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/ResourceDeltaScanner.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/ResourceDeltaScanner.java
@@ -68,6 +68,10 @@ public class ResourceDeltaScanner {
 	 */
 	private List<ResourceDelta> scanDelta(final IResourceDelta delta) throws CoreException {
 		final List<ResourceDelta> events = new ArrayList<ResourceDelta>();
+		if (delta == null) {
+			return Collections.emptyList();
+		}
+		
 		final IResource resource = delta.getResource();
 		// skip as the project is closed
 		if (resource.getType() == IResource.PROJECT && !((IProject) resource).isOpen()) {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsJavaElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsJavaElement.java
@@ -12,8 +12,34 @@
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain;
 
 import static org.eclipse.jdt.core.IJavaElementDelta.CHANGED;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.APPLICATION_PATH;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.CONSUMES;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.DEFAULT_VALUE;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.ENCODED;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.HTTP_METHOD;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.MATRIX_PARAM;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.PATH;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.PATH_PARAM;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.PRODUCES;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.PROVIDER;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.QUERY_PARAM;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.RETENTION;
+import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.TARGET;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_APPLICATION_PATH_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_CONSUMES_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_DEFAULT_VALUE_ANNOTATION;
 import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_ELEMENT_KIND;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_ENCODED_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_HTTP_METHOD_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_MATRIX_PARAM_ANNOTATION;
 import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_NONE;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_PATH_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_PATH_PARAM_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_PRODUCES_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_PROVIDER_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_QUERY_PARAM_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_RETENTION_ANNOTATION;
+import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_TARGET_ANNOTATION;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,6 +58,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils.MapComparison;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementKind;
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsHttpMethod;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
 
 /**
@@ -256,11 +283,57 @@ public abstract class JaxrsJavaElement<T extends IMember> extends JaxrsBaseEleme
 
 	private int qualifyChange(final String annotationName, EnumElementKind previousKind) {
 		final EnumElementKind currentKind = getElementKind();
-		int flag = getMetamodel().computeChangeAnnotationFlag(annotationName);
+		int flag = computeChangeAnnotationFlag(annotationName);
 		if (currentKind != previousKind) {
 			flag += F_ELEMENT_KIND;
 		}
 		return flag;
+	}
+	
+	/**
+	 * Computes the flag associated with the given annotation name
+	 * 
+	 * @param annotationName
+	 *            the annotation fully qualified name
+	 * @return the flag, or {@link JaxrsElementDelta#F_NONE} if the given
+	 *         annotation name is not relevant in the JAX-RS Metamodel
+	 * @see {@link JaxrsElementDelta}
+	 */
+	private int computeChangeAnnotationFlag(final String annotationName) {
+		if (annotationName.equals(PATH.qualifiedName)) {
+			return F_PATH_ANNOTATION;
+		} else if (annotationName.equals(APPLICATION_PATH.qualifiedName)) {
+			return F_APPLICATION_PATH_ANNOTATION;
+		} else if (annotationName.equals(HTTP_METHOD.qualifiedName)) {
+			return F_HTTP_METHOD_ANNOTATION;
+		} else if (annotationName.equals(TARGET.qualifiedName)) {
+			return F_TARGET_ANNOTATION;
+		} else if (annotationName.equals(RETENTION.qualifiedName)) {
+			return F_RETENTION_ANNOTATION;
+		} else if (annotationName.equals(PROVIDER.qualifiedName)) {
+			return F_PROVIDER_ANNOTATION;
+		} else if (annotationName.equals(PATH_PARAM.qualifiedName)) {
+			return F_PATH_PARAM_ANNOTATION;
+		} else if (annotationName.equals(QUERY_PARAM.qualifiedName)) {
+			return F_QUERY_PARAM_ANNOTATION;
+		} else if (annotationName.equals(MATRIX_PARAM.qualifiedName)) {
+			return F_MATRIX_PARAM_ANNOTATION;
+		} else if (annotationName.equals(DEFAULT_VALUE.qualifiedName)) {
+			return F_DEFAULT_VALUE_ANNOTATION;
+		} else if (annotationName.equals(ENCODED.qualifiedName)) {
+			return F_ENCODED_ANNOTATION;
+		} else if (annotationName.equals(CONSUMES.qualifiedName)) {
+			return F_CONSUMES_ANNOTATION;
+		} else if (annotationName.equals(PRODUCES.qualifiedName)) {
+			return F_PRODUCES_ANNOTATION;
+		} else {
+			for (IJaxrsHttpMethod httpMethod : getMetamodel().findAllHttpMethods()) {
+				if (httpMethod.getJavaClassName().equals(annotationName)) {
+					return F_HTTP_METHOD_ANNOTATION;
+				}
+			}
+		}
+		return F_NONE;
 	}
 
 	/**

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/Annotation.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/Annotation.java
@@ -86,8 +86,7 @@ public class Annotation {
 	 *         values) were performed, false otherwise.
 	 */
 	public boolean update(final Annotation otherAnnotation) {
-		assert otherAnnotation != null;
-		if (!hasChanges(otherAnnotation)) {
+		if (otherAnnotation == null || !hasChanges(otherAnnotation)) {
 			return false;
 		}
 		this.javaAnnotationElements.clear();

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JavaMethodSignaturesVisitor.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JavaMethodSignaturesVisitor.java
@@ -125,7 +125,7 @@ public class JavaMethodSignaturesVisitor extends ASTVisitor {
 		// https://issues.jboss.org/browse/JBIDE-15084: when compilation error (not syntax), retrieving return type may result in
 		// an IllegalArgumentException
 		catch(IllegalArgumentException e) {
-			Logger.debug("Caught an IllegalArgumentException while trying to retrieve return type on method {}", methodBinding);
+			Logger.debug("Caught an IllegalArgumentException while trying to retrieve return type on method {}: {}", methodBinding, e.getMessage());
 		}
 		return null;
 	}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/contentassist/MethodParametersCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/contentassist/MethodParametersCompletionProposalComputer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -48,9 +49,9 @@ public class MethodParametersCompletionProposalComputer implements IJavaCompleti
 			IProgressMonitor monitor) {
 		final List<ICompletionProposal> proposals = new ArrayList<ICompletionProposal>();
 		final JavaContentAssistInvocationContext javaContext = (JavaContentAssistInvocationContext) context;
+		final IJavaProject javaProject = javaContext.getProject();
 		try {
-			final IJavaProject project = javaContext.getProject();
-			final IJaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+			final IJaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(javaProject);
 			// skip if the JAX-RS Nature is not configured for this project
 			if (metamodel == null) {
 				return Collections.emptyList();
@@ -61,7 +62,7 @@ public class MethodParametersCompletionProposalComputer implements IJavaCompleti
 					final ITypedRegion region = new TypedRegion(javaContext.getInvocationOffset(), 0, null);
 					//proposals.add(new MethodParametersCompletionProposal("Foo !", new StyledString("Foo!"), region, icon, (IMember) invocationElement));
 			}
-		} catch (Exception e) {
+		} catch (CoreException e) {
 			Logger.error("Failed to compute completion proposal", e);
 		}
 		return proposals; 

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/contentassist/PathParamAnnotationValueCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/contentassist/PathParamAnnotationValueCompletionProposalComputer.java
@@ -76,7 +76,7 @@ public class PathParamAnnotationValueCompletionProposalComputer implements IJava
 			if (metamodel == null) {
 				return Collections.emptyList();
 			}
-			
+			synchronized(metamodel) {
 			final int invocationOffset = context.getInvocationOffset();
 			final ICompilationUnit compilationUnit = javaContext.getCompilationUnit();
 			final Annotation annotation = JdtUtils.resolveAnnotationAt(invocationOffset, compilationUnit);
@@ -86,6 +86,7 @@ public class PathParamAnnotationValueCompletionProposalComputer implements IJava
 				if (resourceMethod != null) {
 					return internalComputePathParamProposals(javaContext, resourceMethod);
 				}
+			}
 			}
 
 		} catch (Exception e) {

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/AbstractCommonTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/AbstractCommonTestCase.java
@@ -198,7 +198,7 @@ public abstract class AbstractCommonTestCase implements IJaxrsElementChangedList
 	}
 
 	@After
-	public void tearDownMetamodelListener() {
+	public void removeMetamodelListener() {
 		if(metamodel != null) {
 			metamodel.removeListener((IJaxrsElementChangedListener)this);
 			metamodel.removeListener((IJaxrsEndpointChangedListener)this);

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/WorkbenchUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/WorkbenchUtils.java
@@ -770,6 +770,8 @@ public class WorkbenchUtils {
 			classpathEntries = (IClasspathEntry[]) ArrayUtils.remove(classpathEntries, index);
 			javaProject.setRawClasspath(classpathEntries, progressMonitor);
 		}
+		// needs to explicitely reopen the java project after setting the new classpath entries
+		javaProject.open(progressMonitor);
 		WorkbenchTasks.buildProject(javaProject.getProject(), progressMonitor);
 		return fragments;
 	}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/domain/JaxrsMetamodelLocatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/domain/JaxrsMetamodelLocatorTestCase.java
@@ -1,0 +1,131 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.ws.jaxrs.core.domain;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.jboss.tools.ws.jaxrs.core.AbstractCommonTestCase;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelLocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author xcoulon
+ * 
+ */
+public class JaxrsMetamodelLocatorTestCase extends AbstractCommonTestCase {
+
+	@Before
+	public void removeMetamodel() {
+		metamodel.remove();
+	}
+
+	@After
+	public void reopenProjects() throws CoreException {
+		project.open(new NullProgressMonitor());
+		javaProject.open(new NullProgressMonitor());
+	}
+
+	@Test
+	public void shouldNotGetMetamodelFromProjectIfMissing() throws CoreException {
+		// pre-condition
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+		// validation
+		assertThat(metamodel, nullValue());
+	}
+
+	@Test
+	public void shouldNotGetMetamodelFromJavaProjectIfMissing() throws CoreException {
+		// pre-condition
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(javaProject);
+		// validation
+		assertThat(metamodel, nullValue());
+	}
+	
+	@Test
+	public void shouldGetMetamodelFromProjectIfNotMissing() throws CoreException {
+		// pre-condition
+		JaxrsMetamodelLocator.get(javaProject, true);
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+		// validation
+		assertThat(metamodel, notNullValue());
+	}
+	
+	@Test
+	public void shouldGetMetamodelFromJavaProjectEvenIfMissing() throws CoreException {
+		// pre-condition
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(javaProject, true);
+		// validation
+		assertThat(metamodel, notNullValue());
+	}
+	
+	@Test
+	public void shouldGetMetamodelFromJavaProjectIfNotMissing() throws CoreException {
+		// pre-condition
+		JaxrsMetamodelLocator.get(javaProject, true);
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(javaProject);
+		// validation
+		assertThat(metamodel, notNullValue());
+	}
+	
+	@Test
+	public void shouldNotGetMetamodelFromClosedProject() throws CoreException {
+		// pre-condition
+		this.project.close(new NullProgressMonitor());
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+		// validation
+		assertThat(metamodel, nullValue());
+
+	}
+
+	@Test
+	public void shouldNotGetMetamodelFromClosedJavaProject() throws CoreException {
+		// pre-condition
+		javaProject.close();
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);
+		// validation
+		assertThat(metamodel, nullValue());
+	}
+
+	@Test
+	public void shouldNotGetMetamodelFromNullProject() throws CoreException {
+		// pre-condition
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get((IProject)null);
+		// validation
+		assertThat(metamodel, nullValue());
+	}
+
+	@Test
+	public void shouldNotGetMetamodelFromNullJavaProject() throws CoreException {
+		// pre-condition
+		// operation
+		final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get((IJavaProject)null);
+		// validation
+		assertThat(metamodel, nullValue());
+	}
+}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedListenerTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementChangedListenerTestCase.java
@@ -1,0 +1,53 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.jboss.tools.ws.jaxrs.core.JBossJaxrsCorePlugin;
+import org.jboss.tools.ws.jaxrs.core.builder.AbstractMetamodelBuilderTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author xcoulon
+ *
+ */
+public class JavaElementChangedListenerTestCase extends AbstractMetamodelBuilderTestCase {
+
+	@Before
+	public void startListeners() {
+		JBossJaxrsCorePlugin.getDefault().resumeListeners();
+	}
+	
+	@After
+	public void stopListeners() {
+		JBossJaxrsCorePlugin.getDefault().pauseListeners();
+	}
+	
+	@Test
+	public void shouldRemoveApplicationWhenRemovingUnderlyingType() throws JavaModelException {
+		// pre-conditions
+		final IType applicationType = metamodel.getJavaApplications().get(0).getJavaElement();
+		// operation
+		final ICompilationUnit workingCopy = applicationType.getCompilationUnit().getWorkingCopy(new NullProgressMonitor());
+		workingCopy.findPrimaryType().delete(true, new NullProgressMonitor());
+		// verifications
+		assertThat(metamodel.getJavaApplications().size(), equalTo(0));
+	}
+}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScannerTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScannerTestCase.java
@@ -41,6 +41,7 @@ import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -143,10 +144,12 @@ public class JavaElementDeltaScannerTestCase extends AbstractCommonTestCase {
 	}
 
 	@After
-	public void removeAndRestoreListeners() {
+	public void removeAndRestoreListeners() throws CoreException, OperationCanceledException, InterruptedException {
+		project.open(new NullProgressMonitor());
+		javaProject.open(new NullProgressMonitor());
+		WorkbenchTasks.buildProject(project, null);
 		JavaCore.removeElementChangedListener(elementChangeListener);
 		ResourcesPlugin.getWorkspace().removeResourceChangeListener(resourceChangeListener);
-		// JBossJaxrsCorePlugin.getDefault().registerListeners();
 	}
 
 	private void verifyEventNotification(IJavaElement element, int deltaKind, int eventType, int flags,
@@ -1143,5 +1146,23 @@ public class JavaElementDeltaScannerTestCase extends AbstractCommonTestCase {
 		for (IMethod method : type.getMethods()) {
 			verifyEventNotification(method.getResource(), CHANGED, POST_CHANGE, F_SIGNATURE, atLeastOnce());
 		}
+	}
+	
+	@Test
+	public void shoudIgnoreEventOnCloseProject() throws CoreException {
+		// pre-condition
+		// operation
+		project.close(new NullProgressMonitor());
+		// verification
+		verify(resourceEvents, never());
+	}
+
+	@Test
+	public void shoudIgnoreEventOnCloseJavaProject() throws CoreException {
+		// pre-condition
+		// operation
+		javaProject.close();
+		// verification
+		verify(resourceEvents, never());
 	}
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtilsTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtilsTestCase.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -523,8 +524,29 @@ public class JdtUtilsTestCase extends AbstractCommonTestCase {
 				for (Entry<String, Annotation> annotationEntry : methodParameter.getAnnotations().entrySet()) {
 					assertNotNull("JavaAnnotation for " + methodParameter.getName() + "." + annotationEntry.getKey()
 							+ " is null", annotationEntry.getValue().getJavaAnnotation());
+					assertNotNull(methodSignature.toString());
 				}
 			}
+		}
+		// testing equals() and hashcode() methods here.
+		for(Iterator<Entry<String, JavaMethodSignature>> iterator1 = methodSignatures.entrySet().iterator(); iterator1.hasNext();) {
+			final Entry<String, JavaMethodSignature> entry1 = iterator1.next();
+			final String key1 = entry1.getKey();
+			final JavaMethodSignature methodSignature1 = entry1.getValue();
+			for(Iterator<Entry<String, JavaMethodSignature>> iterator2 = methodSignatures.entrySet().iterator(); iterator2.hasNext();) {
+				final Entry<String, JavaMethodSignature> entry2 = iterator2.next();
+				final String key2 = entry2.getKey();
+				final JavaMethodSignature methodSignature2 = entry2.getValue();
+				if(key1.equals(key2)) {
+					assertThat(methodSignature1.equals(methodSignature2), equalTo(true));
+					assertThat(methodSignature1.hashCode() == methodSignature2.hashCode(), equalTo(true));
+				} else {
+					assertThat(methodSignature1.equals(methodSignature2), equalTo(false));
+					assertThat(methodSignature1.hashCode() == methodSignature2.hashCode(), equalTo(false));
+				}
+			}
+			
+			
 		}
 	}
 


### PR DESCRIPTION
Added accepted change event on a project: RESOLVED_CLASSPATH. This event is triggered when m2e adds the dependencies as libraries to the
project. In that case, a metamodel build should be triggered as it may resolve some compilation problems.

Move the call the JaxrsMetamodel#setBuildStatus() to finally{} blocks of JaxrsMetamodel#processXXX() methods

Adjusted some javadoc, log messages and catch() blocks (avoiding to catch Exception or Throwable)

Also, added a few synchronized() blocks to avoid concurrent access to the metamodel by different threads, for example if an async build
is still running and the validation is started. This avoids the following type of error:

{code}
!ENTRY org.jboss.tools.common 4 0 2013-10-09 18:17:54.307
!MESSAGE
!STACK 0
org.jboss.tools.common.validation.JBTValidationException
    at org.jboss.tools.common.validation.ValidatorManager.validateInJob(ValidatorManager.java:101)
    at org.eclipse.wst.validation.internal.operations.ValidatorJob.run(ValidatorJob.java:78)
    at org.eclipse.core.internal.jobs.Worker.run(Worker.java:53)
Caused by: java.util.ConcurrentModificationException
    at java.util.HashMap$HashIterator.nextEntry(HashMap.java:793)
    at java.util.HashMap$ValueIterator.next(HashMap.java:822)
    at org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.JaxrsMetamodelValidator.validateAll(JaxrsMetamodelValidator.java:268)
    at org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.JaxrsMetamodelValidator.validate(JaxrsMetamodelValidator.java:153)
    at org.jboss.tools.common.validation.ValidatorManager.validate(ValidatorManager.java:117)
    at org.jboss.tools.common.validation.ValidatorManager.validateInJob(ValidatorManager.java:81)
    ... 2 more
{code}
