### PR TITLE
JBIDE-15839 - Exception while saving Provider in JAX-RS application

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidator.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidator.java
@@ -417,8 +417,10 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 		final IProject project = metamodel.getProject();
 		Logger.debug("Reporting problem '{}' on project '{}'", message, project.getName());
 		final IMarker marker = addProblem(message, preferenceKey, messageArguments, 0, 0, project);
-		marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
-		metamodel.registerMarker(marker);
+		if(marker != null) { 
+			marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
+			metamodel.registerMarker(marker);
+		}
 		return marker;
 	}
 	
@@ -430,8 +432,10 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 		final IResource resource = element.getResource();
 		Logger.debug("Reporting problem '{}' on resource '{}'", message, resource.getFullPath().toString());
 		final IMarker marker = addProblem(message, preferenceKey, messageArguments, range.getLength(), range.getOffset(), resource);
-		marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
-		element.registerMarker(marker);
+		if(marker != null) {
+			marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
+			element.registerMarker(marker);
+		}
 		return marker;
 	}
 
@@ -443,8 +447,10 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 		final IResource resource = element.getResource();
 		Logger.debug("Reporting problem '{}' on resource '{}'", message, resource.getFullPath().toString());
 		final IMarker marker = addProblem(message, preferenceKey, messageArguments, range.getLength(), range.getOffset(), resource, quickFixId);
-		marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
-		element.registerMarker(marker);
+		if(marker != null) {
+			marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
+			element.registerMarker(marker);
+		}
 		return marker;
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/preferences/JaxrsPreferenceInitializer.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/preferences/JaxrsPreferenceInitializer.java
@@ -28,7 +28,7 @@ public class JaxrsPreferenceInitializer extends AbstractPreferenceInitializer {
 	 */
 	@Override
 	public void initializeDefaultPreferences() {
-		IEclipsePreferences defaultPreferences = ((IScopeContext)DefaultScope.INSTANCE).getNode(JBossJaxrsCorePlugin.PLUGIN_ID);
+		final IEclipsePreferences defaultPreferences = ((IScopeContext)DefaultScope.INSTANCE).getNode(JBossJaxrsCorePlugin.PLUGIN_ID);
 		defaultPreferences.put(SeverityPreferences.ENABLE_BLOCK_PREFERENCE_NAME, SeverityPreferences.ENABLE);
 		defaultPreferences.put(SeverityPreferences.WRONG_BUILDER_ORDER_PREFERENCE_NAME, JaxrsPreferences.ERROR);
 		for (String name : JaxrsPreferences.SEVERITY_OPTION_NAMES) {

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
@@ -32,7 +32,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.ltk.core.refactoring;bundle-version="3.5.200",
  org.eclipse.wst.validation;bundle-version="1.2.300",
  org.apache.commons.io;bundle-version="2.0.1",
- org.jboss.tools.common.validation;bundle-version="3.4.0"
+ org.jboss.tools.common.validation;bundle-version="3.4.0",
+ org.jboss.tools.common.core;bundle-version="3.5.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Eclipse-RegisterBuddy: org.apache.log4j

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorTestCase.java
@@ -70,5 +70,4 @@ public class JaxrsMetamodelValidatorTestCase extends AbstractMetamodelBuilderTes
 		assertThat(metamodelProblemLevelChanges.size(), is(0));
 	}
 	
-	
 }


### PR DESCRIPTION
Fixed the problem which occurred only when the problem severity as set to
'ignore' level. In that particular case, no IMarker would be created, thus
returning a null reference, which lead to NPE.

Added a JUnit test to cover that.
