### PR TITLE
JBIDE-15908 - Problem decorator is not removed after error was fixed

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
@@ -62,11 +62,17 @@ public abstract class JaxrsBaseElement implements IJaxrsElement {
 	 * 
 	 * @param problem
 	 *            level: the incoming new problem level.
-	 * @throws CoreException 
 	 */
 	@Deprecated
 	public void setProblemLevel(final int problemLevel) {
 		this.problemLevel = Math.max(this.problemLevel, problemLevel);
+	}
+	
+	/**
+	 * Sets the problem level to {@code 0} for this element.
+	 */
+	public void resetProblemLevel() {
+		this.problemLevel = 0;
 	}
 	
 	/**

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsResource.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsResource.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -250,6 +251,18 @@ public class JaxrsResource extends JaxrsJavaElement<IType> implements IJaxrsReso
 			}
 		}
 
+	}
+	
+	/**
+	 * Removes the JAX-RS {@link IMarker} and resets the problem level for this
+	 * {@link IJaxrsResource}, and at the same time, sets the problem level to
+	 * {@code zero} for all its {@link IJaxrsResourceField}s and
+	 * {@link IJaxrsResourceMethod}s children.
+	 * 
+	 * @throws CoreException
+	 */
+	public void removeMarkers() throws CoreException {
+		super.removeMarkers();
 	}
 
 	/**

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
@@ -66,6 +66,7 @@ public class JaxrsResourceMethodValidatorDelegate extends AbstractJaxrsElementVa
 	@Override
 	void internalValidate(final JaxrsResourceMethod resourceMethod) throws CoreException {
 		Logger.debug("Validating element {}", resourceMethod);
+		resourceMethod.resetProblemLevel();
 		validatePublicModifierOnJavaMethod(resourceMethod);
 		validateNoUnboundPathAnnotationTemplateParameters(resourceMethod);
 		validateNoUnboundPathParamAnnotationValues(resourceMethod);

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/utils/CollectionUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/utils/CollectionUtils.java
@@ -13,10 +13,8 @@ package org.jboss.tools.ws.jaxrs.core.internal.utils;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Collections utility class.
@@ -331,20 +329,6 @@ public class CollectionUtils {
 			return removedItems;
 		}
 
-	}
-
-	/**
-	 * Converts the given elements into a set
-	 * 
-	 * @param elements
-	 * @return the set containing the given elements
-	 */
-	public static <T> Set<T> toSet(final T... elements) {
-		final Set<T> result = new HashSet<T>();
-		for (T element : elements) {
-			result.add(element);
-		}
-		return result;
 	}
 
 	/**

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsApplicationValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsApplicationValidatorTestCase.java
@@ -14,9 +14,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.deleteJaxrsMarkers;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.findJaxrsMarkers;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.hasPreferenceKey;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.deleteJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.findJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.hasPreferenceKey;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.toSet;
 import static org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences.APPLICATION_NO_OCCURRENCE_FOUND;
 import static org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences.APPLICATION_TOO_MANY_OCCURRENCES;
 import static org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences.JAVA_APPLICATION_INVALID_TYPE_HIERARCHY;
@@ -49,7 +50,6 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsBaseElement;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsEndpoint;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaApplication;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsWebxmlApplication;
-import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsApplication;
@@ -168,8 +168,8 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		// operation: validate one app twice
 		final IFile file1 = (IFile)project.findMember(".project");
 		final IFile file2 = (IFile)project.findMember(".classpath");
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(file1), project, validationHelper, context, validatorManager, reporter);
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(file2), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(file1), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(file2), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(project);
 		assertThat(markers.length, equalTo(0));
@@ -348,7 +348,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		final IFile app2Resource = (IFile) restApplication2Type.getResource();
 		//app2Resource.delete(true, new NullProgressMonitor());
 		// then validate again, only the *changed files* (and without reset). Expect marker on first application to be removed
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(app2Resource), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(app2Resource), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(javaApplication).length, equalTo(0));
 		assertThat(findJaxrsMarkers(javaApplication2).length, equalTo(0));
@@ -381,7 +381,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		final IFile app2Resource = (IFile) restApplication2Type.getResource();
 		app2Resource.delete(true, new NullProgressMonitor());
 		// then validate again, only the *changed files* (and without reset). Expect marker on first application to be removed
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(app2Resource), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(app2Resource), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(javaApplication).length, equalTo(0));
 		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
@@ -435,7 +435,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		final IFile appResource = (IFile) javaApplication.getResource();
 		appResource.delete(true, new NullProgressMonitor());
 		// then validate again, only the *changed files* (and without reset). Expect marker on we.xml application definition to be removed
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(appResource), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(appResource), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(webxmlApplication).length, equalTo(0));
 		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
@@ -464,7 +464,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		final IFile webxmlResource = (IFile) webxmlApplication.getResource();
 		webxmlResource.delete(true, new NullProgressMonitor());
 		// then validate again, only the *changed files* (and without reset). Expect marker on first application to be removed
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(webxmlResource), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(webxmlResource), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(javaApplication).length, equalTo(0));
 		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
@@ -498,7 +498,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		final IFile webxmlResource = (IFile) webxmlApplication.getResource();
 		webxmlResource.delete(true, new NullProgressMonitor());
 		// then validate again, only the *changed files* (and without reset). Expect marker on both applications to be still there
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(webxmlResource), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(webxmlResource), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(javaApplication).length, equalTo(1));
 		// restApplication2 has 2 markers: missing annotation and duplicate application
@@ -535,7 +535,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		// remove content, no remove resource
 		webxmlResource = (IFile) WorkbenchUtils.replaceDeploymentDescriptorWith(javaProject, "web-3_0-without-servlet-mapping.xml");
 		// then validate again, only the *changed files* (and without reset). Expect marker on both applications to be still there
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet(webxmlResource), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(webxmlResource), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(javaApplication).length, equalTo(1));
 		// restApplication2 has 2 markers: missing annotation and duplicate application
@@ -551,7 +551,7 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		new JaxrsMetamodelValidator().validate(CollectionUtils.toSet((IFile)project.findMember(".project")), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(toSet(project.findMember(".project")), project, validationHelper, context, validatorManager, reporter);
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(project);
 		assertThat(markers.length, equalTo(0));
@@ -584,5 +584,27 @@ public class JaxrsApplicationValidatorTestCase extends AbstractMetamodelBuilderT
 		assertThat(markers.length, equalTo(0));
 	}
 
+	@Test
+	public void shouldIncreaseAndResetProblemLevelOnApplication() throws CoreException, ValidationException {
+		// preconditions
+		final JaxrsWebxmlApplication webxmlApplication = metamodel.findWebxmlApplication();
+		webxmlApplication.remove();
+		final IType type = resolveType("org.jboss.tools.ws.jaxrs.sample.services.RestApplication");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(type.getCompilationUnit(), "extends Application", "extends Object", false);
+		final JaxrsJavaApplication javaApplication = metamodel.getJavaApplications().get(0);
+		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validateAll(project, validationHelper, context, validatorManager, reporter);
+		// verification: problem level is set to '2'
+		assertThat(javaApplication.getProblemLevel(), equalTo(2));
+		// now, fix the problem 
+		WorkbenchUtils.replaceAllOccurrencesOfCode(type.getCompilationUnit(), "extends Object", "extends Application", false);
+		// revalidate
+		new JaxrsMetamodelValidator().validate(toSet(javaApplication.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// verification: problem level is set to '0'
+		assertThat(javaApplication.getProblemLevel(), equalTo(0));
+	}
 	
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsMetamodelValidatorTestCase.java
@@ -12,8 +12,8 @@ package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.deleteJaxrsMarkers;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.findJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.deleteJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.findJaxrsMarkers;
 import static org.junit.Assert.assertThat;
 
 import org.eclipse.core.resources.IFile;

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsProviderValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsProviderValidatorTestCase.java
@@ -11,8 +11,9 @@
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.deleteJaxrsMarkers;
-import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.MarkerUtils.findJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.deleteJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.findJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.toSet;
 import static org.jboss.tools.ws.jaxrs.core.jdt.EnumJaxrsClassname.PROVIDER;
 import static org.junit.Assert.assertThat;
 
@@ -43,7 +44,6 @@ import org.jboss.tools.ws.jaxrs.core.WorkbenchUtils;
 import org.jboss.tools.ws.jaxrs.core.builder.AbstractMetamodelBuilderTestCase;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsBaseElement;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsProvider;
-import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsElement;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsProvider;
@@ -93,7 +93,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -119,7 +119,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -143,7 +143,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -170,7 +170,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -197,7 +197,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -224,7 +224,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -251,7 +251,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -279,7 +279,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
+		final Set<IFile> changedResources = toSet( provider.getResource(),
 				(IFile) otherProvider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
@@ -308,7 +308,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
+		final Set<IFile> changedResources = toSet( provider.getResource(),
 				(IFile) otherProvider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
@@ -337,7 +337,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
+		final Set<IFile> changedResources = toSet( provider.getResource(),
 				(IFile) otherProvider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
@@ -367,7 +367,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource(),
+		final Set<IFile> changedResources = toSet( provider.getResource(),
 				(IFile) otherProvider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
@@ -391,7 +391,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -414,7 +414,7 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		deleteJaxrsMarkers(project);
 		resetElementChangesNotifications();
 		// operation
-		final Set<IFile> changedResources = CollectionUtils.toSet((IFile) provider.getResource());
+		final Set<IFile> changedResources = toSet( provider.getResource());
 		new JaxrsMetamodelValidator().validate(changedResources, project, validationHelper, context, validatorManager,
 				reporter);
 		// validation
@@ -485,6 +485,31 @@ public class JaxrsProviderValidatorTestCase extends AbstractMetamodelBuilderTest
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(provider);
 		assertThat(markers.length, equalTo(0));
+	}
+	
+	@Test
+	public void shouldIncreaseAndResetProblemLevelOnHttpMethod() throws CoreException, ValidationException {
+		// preconditions
+		final IType providerType = resolveType("org.jboss.tools.ws.jaxrs.sample.services.providers.EntityNotFoundExceptionMapper");
+		WorkbenchUtils.replaceFirstOccurrenceOfCode(providerType, "ExceptionMapper<EntityNotFoundException>",
+				"ExceptionMapper<Foobar>", false);
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType);
+		removeAllElementsExcept(provider);
+		deleteJaxrsMarkers(project);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(provider.getResource()), project, validationHelper, context,
+				validatorManager, reporter);
+		// verification: problem level is set to '2'
+		assertThat(provider.getProblemLevel(), equalTo(2));
+		// now, fix the problem 
+		WorkbenchUtils.replaceFirstOccurrenceOfCode(providerType, "ExceptionMapper<Foobar>",
+				"ExceptionMapper<EntityNotFoundException>", false);
+		// revalidate
+		new JaxrsMetamodelValidator().validate(toSet(provider.getResource()), project, validationHelper, context,
+				validatorManager, reporter);
+		// verification: problem level is set to '0'
+		assertThat(provider.getProblemLevel(), equalTo(0));
 	}
 
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/ValidationUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/ValidationUtils.java
@@ -1,8 +1,11 @@
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -19,8 +22,22 @@ import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsElement;
 /**
  * @author Xavier Coulon The class name says it all.
  */
-public class MarkerUtils {
+public class ValidationUtils {
 
+	/**
+	 * Converts the given {@link IResource} elements into a set of {@link IFile}s
+	 * 
+	 * @param elements
+	 * @return the set containing the given elements
+	 */
+	public static Set<IFile> toSet(final IResource... elements) {
+		final Set<IFile> result = new HashSet<IFile>();
+		for (IResource element : elements) {
+			result.add((IFile)element);
+		}
+		return result;
+	}
+	
 	/**
 	 * find JAX-RS Markers on the given resources.
 	 * 


### PR DESCRIPTION
Bug was that the problemLevel on each JAX-RS Resource Method would not
be reset at the beginning of the validation, and during validation, the
highest problem level is kept. Thus, during the next validation (fixing
the problem), the problem level would remain at its highest (previous)
value.

Added tests to verify the correct behaviour on all validators.
