### PR TITLE
JBIDE-16137 - webservices component build slow during tests on MacOSX 10.7

### DIFF
--- a/tests/org.jboss.tools.ws.creation.core.test/pom.xml
+++ b/tests/org.jboss.tools.ws.creation.core.test/pom.xml
@@ -44,6 +44,11 @@
 							<artifactId>org.eclipse.jpt.jpa.feature.feature.group</artifactId>
 							<version>0.0.0</version>
 						</dependency>
+						<dependency>
+							<type>eclipse-feature</type>
+							<artifactId>org.eclipse.e4.rcp</artifactId>
+							<version>0.0.0</version>
+						</dependency>
 					</dependencies>
 				</configuration>
 			</plugin>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -18,5 +18,23 @@
 		<module>org.jboss.tools.ws.ui.test</module>
 		<module>org.jboss.tools.ws.jaxrs.core.test</module>
 	</modules>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tychoVersion}</version>
+				<configuration>
+					<dependencies>
+						<dependency>
+							<type>eclipse-feature</type>
+							<artifactId>org.eclipse.e4.rcp</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+					</dependencies>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>
 	


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-16137
webservices component build slow during tests on MacOSX 10.7
