### PR TITLE
JBIDE-16328 - Buglets in JaxrsResourceMethodValidatorDelegate.validatePublicModifierOnJavaMethod()

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
@@ -25,8 +25,10 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.SourceRange;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceMethod;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
@@ -242,10 +244,14 @@ public class JaxrsResourceMethodValidatorDelegate extends AbstractJaxrsElementVa
 	 */
 	private void validatePublicModifierOnJavaMethod(final JaxrsResourceMethod resourceMethod) throws CoreException {
 		final IMethod javaMethod = resourceMethod.getJavaElement();
-		if (javaMethod != null && !Flags.isPublic(javaMethod.getFlags())) {
+		final JaxrsResource parentResource = resourceMethod.getParentResource();
+		if(javaMethod == null || parentResource == null || parentResource.getJavaElement() == null) {
+			return;
+		}
+		if (!parentResource.getJavaElement().isInterface() && !Flags.isPublic(javaMethod.getFlags())) {
 			final ISourceRange nameRange = javaMethod.getNameRange();
 			markerManager.addMarker(resourceMethod,
-					nameRange, JaxrsValidationMessages.RESOURCE_METHOD_NO_PUBLIC_MODIFIER, new String[0], JaxrsPreferences.RESOURCE_METHOD_NO_PUBLIC_MODIFIER);
+					nameRange, JaxrsValidationMessages.RESOURCE_METHOD_NO_PUBLIC_MODIFIER, new String[]{resourceMethod.getName()}, JaxrsPreferences.RESOURCE_METHOD_NO_PUBLIC_MODIFIER);
 		}
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/resources/IValidationResource.txt
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/resources/IValidationResource.txt
@@ -1,0 +1,21 @@
+package org.jboss.tools.ws.jaxrs.sample.services;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Context;
+
+@Path("/rest/{type}")
+public interface IValidationResource {
+
+    @GET
+	@Path("/{id}/{format:(/format/[^/]+?)?}/{encoding:(/encoding/[^/]+?)?}")
+	Response getContent2(@PathParam("id") int id,
+				  @PathParam("type") String type,
+				  @PathParam("format") String format,
+				  @PathParam("encoding") String encoding, 
+				  @QueryParam("start") int start);
+	
+}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorTestCase.java
@@ -11,7 +11,9 @@
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.deleteJaxrsMarkers;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.findJaxrsMarkers;
 import static org.jboss.tools.ws.jaxrs.core.internal.metamodel.validation.ValidationUtils.hasPreferenceKey;
@@ -156,7 +158,7 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 	}
 
 	@Test
-	public void shouldReportProblemOnNonPublicJavaMethod() throws CoreException, ValidationException {
+	public void shouldReportProblemOnNonPublicJavaMethodInImplementationClass() throws CoreException, ValidationException {
 		// pre-conditions
 		ICompilationUnit compilationUnit = WorkbenchUtils.createCompilationUnit(javaProject, "ValidationResource.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "ValidationResource.java");
@@ -172,10 +174,28 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 		// verification
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers[0].getAttribute(IMarker.LINE_NUMBER, 0), equalTo(15));
+		assertThat(markers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{0}")));
 		assertThat(metamodelProblemLevelChanges.contains(metamodel), is(true));
 		assertThat(metamodelProblemLevelChanges.size(), is(1));
 	}
 
+	@Test
+	public void shouldNotReportProblemOnNonPublicJavaMethodInInterface() throws CoreException, ValidationException {
+		// pre-conditions
+		ICompilationUnit compilationUnit = WorkbenchUtils.createCompilationUnit(javaProject, "IValidationResource.txt",
+				"org.jboss.tools.ws.jaxrs.sample.services", "IValidationResource.java");
+		final JaxrsResource resource = (JaxrsResource) metamodel.findElement(compilationUnit.findPrimaryType());
+		deleteJaxrsMarkers(resource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(compilationUnit.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(resource);
+		// verification
+		assertThat(markers.length, equalTo(0));
+	}
+	
 	@Test
 	public void shouldReportProblemOnUnboundTypePathArgument() throws ValidationException, CoreException {
 		// pre-conditions


### PR DESCRIPTION
Fixed the incomplete validation message ('{0}' was not substitued).
Added an exception if the parent type is an interface.
