### PR TITLE
JBIDE-16264 - @PathParam with hyphen in value shows as JAX-RS error

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceMethodValidatorDelegate.java
@@ -50,7 +50,7 @@ public class JaxrsResourceMethodValidatorDelegate extends AbstractJaxrsElementVa
 			"javax.servlet.http.HttpServletRequest", "javax.servlet.http.HttpServletResponse",
 			"javax.servlet.ServletConfig", "javax.servlet.ServletContext", "javax.ws.rs.core.SecurityContext"));
 
-	private static final Pattern alphaNumPattern = Pattern.compile("[a-zA-Z1-9]+");
+	private static final Pattern alphaNumPattern = Pattern.compile("[a-zA-Z1-9]([a-zA-Z1-9]|\\.|-|_)*");
 
 	private final IMarkerManager markerManager;
 	
@@ -187,8 +187,8 @@ public class JaxrsResourceMethodValidatorDelegate extends AbstractJaxrsElementVa
 						markerManager.addMarker(
 								resourceMethod,
 								range,
-								JaxrsValidationMessages.RESOURCE_METHOD_UNBOUND_PATHPARAM_ANNOTATION_VALUE, new String[] { pathParamValue },
-								JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATHPARAM_ANNOTATION_VALUE);
+								JaxrsValidationMessages.RESOURCE_METHOD_INVALID_PATHPARAM_ANNOTATION_VALUE, new String[] { pathParamValue },
+								JaxrsPreferences.RESOURCE_METHOD_INVALID_PATHPARAM_ANNOTATION_VALUE);
 					} else if (!pathParamValueProposals.keySet().contains(pathParamValue)) {
 						final ISourceRange range = JdtUtils.resolveMemberPairValueRange(
 								pathParamAnnotation.getJavaAnnotation(), "value");

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/validation/JaxrsResourceValidatorTestCase.java
@@ -40,6 +40,7 @@ import org.jboss.tools.ws.jaxrs.core.builder.AbstractMetamodelBuilderTestCase;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsBaseElement;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceMethod;
+import org.jboss.tools.ws.jaxrs.core.preferences.JaxrsPreferences;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -332,6 +333,169 @@ public class JaxrsResourceValidatorTestCase extends AbstractMetamodelBuilderTest
 				context, validatorManager, reporter);
 		// verification: problem level is set to '0'
 		assertThat(resource.getAllMethods().get(0).getProblemLevel(), equalTo(0));
+	}
+	
+	@Test
+	public void shouldValidateCustomerResourceMethodWithDotCharacterInPathParam() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i.d}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"i.d\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
+	}
+
+	@Test
+	public void shouldNotValidateCustomerResourceMethodWithDotCharacterInPathParamInFirstPlace() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{.id}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\".id\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(4));
+		for(IMarker marker : markers) {
+			assertThat((String)marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
+			assertThat((String)marker.getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE), equalTo(JaxrsPreferences.RESOURCE_METHOD_INVALID_PATHPARAM_ANNOTATION_VALUE));
+		}
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
+	}
+	
+	@Test
+	public void shouldValidateCustomerResourceMethodWithHyphenCharacterInPathParam() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i-d}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"i-d\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
+	}
+	
+	@Test
+	public void shouldNotValidateCustomerResourceMethodWithHyphenCharacterInPathParamInFirstPlace() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{-id}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"-id\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(4));
+		for(IMarker marker : markers) {
+			assertThat((String)marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
+			assertThat((String)marker.getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE), equalTo(JaxrsPreferences.RESOURCE_METHOD_INVALID_PATHPARAM_ANNOTATION_VALUE));
+		}
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
+	}
+	
+
+
+	@Test
+	public void shouldValidateCustomerResourceMethodWithUnderscoreCharacterInPathParam() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i_d}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"i_d\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(0));
+		assertThat(metamodelProblemLevelChanges.size(), is(0));
+	}
+	
+	@Test
+	public void shouldNotValidateCustomerResourceMethodWithUnderscoreCharacterInPathParamInFirstPlace() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{_id}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"_id\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(4));
+		for(IMarker marker : markers) {
+			assertThat((String)marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
+			assertThat((String)marker.getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE), equalTo(JaxrsPreferences.RESOURCE_METHOD_INVALID_PATHPARAM_ANNOTATION_VALUE));
+		}
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
+	}
+	
+
+
+	@Test
+	public void shouldNotValidateCustomerResourceMethodWithAtCharacterInPathParam() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i@d}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"i@d\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(4));
+		for(IMarker marker : markers) {
+			assertThat((String)marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
+			assertThat((String)marker.getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE), equalTo(JaxrsPreferences.RESOURCE_METHOD_INVALID_PATHPARAM_ANNOTATION_VALUE));
+		}
+		assertThat(metamodelProblemLevelChanges.size(), is(1));
+	}
+
+	@Test
+	public void shouldNotValidateCustomerResourceMethodWithSingleCharacterInPathParam() throws CoreException, ValidationException {
+		// preconditions
+		final IType customerJavaType = getType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i}\")", false);
+		WorkbenchUtils.replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"i\")", false);
+		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel.findElement(customerJavaType);
+		deleteJaxrsMarkers(customerResource);
+		resetElementChangesNotifications();
+		// operation
+		new JaxrsMetamodelValidator().validate(toSet(customerResource.getResource()), project, validationHelper,
+				context, validatorManager, reporter);
+		// validation
+		final IMarker[] markers = findJaxrsMarkers(customerResource);
+		assertThat(markers.length, equalTo(0));
 	}
 
 }


### PR DESCRIPTION
Fixing the reported error type (was wrong id)
Allowing for hyphen, underscore and dot characters but in first position
for the path parameters.
Added JUnit tests.
