### PR TITLE
JBIDE-15827 - Failed to remove JAX-RS Metamodel when closing a project

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -322,16 +322,15 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	 * @throws IOException
 	 * @throws CorruptIndexException
 	 */
-	public final void remove() {
+	public final void remove() throws CoreException {
 		try {
 			readWriteLock.writeLock().lock();
 			indexationService.dispose();
 			final IProject project = getProject();
 			if(project.exists() && project.isOpen()) {
 				project.setSessionProperty(METAMODEL_QUALIFIED_NAME, null);
-				project.deleteMarkers(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID, true, IResource.DEPTH_INFINITE);
 			}
-		} catch (Exception e) {
+		} catch (IOException e) {
 			Logger.error("Failed to remove JAX-RS Metamodel for project " + javaProject.getElementName(), e);
 		} finally {
 			Logger.debug("JAX-RS Metamodel removed for project " + javaProject.getElementName());

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodelTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodelTestCase.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -42,6 +43,7 @@ import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsHttpMethod;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResourceMethod;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
+import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelLocator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -75,7 +77,7 @@ public class JaxrsMetamodelTestCase {
 	}
 
 	@Test
-	public void shouldnotFindHttpMethodByNullType() throws CoreException {
+	public void shouldNotFindHttpMethodByNullType() throws CoreException {
 		assertThat(metamodel.findHttpMethodByTypeName(null), nullValue());
 	}
 	
@@ -280,5 +282,5 @@ public class JaxrsMetamodelTestCase {
 		// verifications
 		assertThat(metamodelMonitor.getElementChanges().size(), equalTo(0));
 	}
-
+	
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
@@ -120,6 +120,9 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsE
 				metamodel.removeListener((IJaxrsEndpointChangedListener) this);
 				metamodel.remove();
 			}
+		} catch (CoreException e) {
+			e.printStackTrace();
+			fail("Failed to remove metamodel: " + e.getMessage());
 		} finally {
 			long endTime = new Date().getTime();
 			LOGGER.info("Test Workspace sync'd in " + (endTime - startTime) + "ms.");


### PR DESCRIPTION
Removed the call to delete markers on project while it was being closed, which
was not necessary and caused the reported CoreException.
