### PR TITLE
JBIDE-16834 - Build failures on org.jboss.tools.ws.jaxrs.ui.test

### DIFF
--- a/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Version: 1.7.0.qualifier
 Bundle-Activator: org.jboss.tools.ws.jaxrs.core.JBossJaxrsCoreTestPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.jboss.tools.ws.jaxrs.core;bundle-version="1.2.2",
- org.eclipse.jdt.launching.macosx;bundle-version="3.2.100";resolution:=optional;visibility:=reexport,
+ org.eclipse.jdt.launching.macosx;bundle-version="3.2.100";resolution:=optional,
  org.eclipse.ui.ide;bundle-version="3.7.0",
  org.slf4j.api;bundle-version="1.6.1",
  org.apache.commons.lang;bundle-version="2.1.0",

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/WorkbenchTasks.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/WorkbenchTasks.java
@@ -143,9 +143,10 @@ public class WorkbenchTasks {
 			project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
 			IMarker[] projectMarkers = project.findMarkers(null, true, IResource.DEPTH_INFINITE);
-			System.err.println("Project markers:");
 			for(IMarker marker : projectMarkers) {
-				System.err.println(" " + marker.getAttribute(IMarker.MESSAGE, ""));
+				if(marker.getAttribute(IMarker.SEVERITY, 0) == IMarker.SEVERITY_ERROR) {
+					System.err.println(" " + marker.getAttribute(IMarker.MESSAGE, ""));
+				}
 			}
 			return project;
 		} finally {

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/META-INF/MANIFEST.MF
@@ -23,7 +23,9 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.common.core,
  org.jboss.tools.ws.jaxrs.core,
  org.jboss.tools.ws.jaxrs.core.test,
- org.hamcrest.library
+ org.hamcrest.library,
+ org.eclipse.jdt.launching,
+ org.eclipse.jdt.launching.macosx;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Eclipse-RegisterBuddy: org.apache.log4j


### PR DESCRIPTION
Fixing build failures on org.jboss.tools.ws.jaxrs.ui.test because of missing dependency org.eclipse.jdt.launch
This caused the sample project in the runtime workspace to _not_ have a JRE to be compiled, which prevented the
project build and the JAX-RS Metamodel build.
