### PR TITLE
JBIDE-16476 - JAX-RS explorer shows url with slash before matrix parameters

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpoint.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpoint.java
@@ -314,12 +314,12 @@ public class JaxrsEndpoint implements IJaxrsEndpoint {
 		final JaxrsResourceMethod firstResourceMethod = resourceMethods.get(0);
 		final String displayableResourcePathTemplate = getDisplayablePathTemplate(firstResourceMethod.getParentResource(), firstResourceMethod);
 		if (!displayableResourcePathTemplate.isEmpty()) {
-			uriPathTemplateBuilder.append("/").append(displayableResourcePathTemplate);
+			uriPathTemplateBuilder.append(displayableResourcePathTemplate);
 		}
 		for (JaxrsResourceMethod resourceMethod : resourceMethods) {
 			final String displayableResourceMethodPathTemplate = getDisplayablePathTemplate(resourceMethod);
 			if (!displayableResourceMethodPathTemplate.isEmpty()) {
-				uriPathTemplateBuilder.append("/").append(displayableResourceMethodPathTemplate);
+				uriPathTemplateBuilder.append(displayableResourceMethodPathTemplate);
 			}
 			final List<String> displayableResourceMethodQueryParameters = getDisplayableQueryParameters(resourceMethod);
 			queryParams.addAll(displayableResourceMethodQueryParameters);
@@ -354,6 +354,10 @@ public class JaxrsEndpoint implements IJaxrsEndpoint {
 		int index = 0;
 		if(resource.getPathTemplate() != null) {
 			while (index < resource.getPathTemplate().length()) {
+				// make sure the path template starts with a '/'. 
+				if(!resource.getPathTemplate().startsWith("/")) {
+					pathTemplateBuilder.append('/');
+				}
 				final int beginIndex = resource.getPathTemplate().indexOf('{', index);
 				final int endIndex = resource.getPathTemplate().indexOf('}', beginIndex + 1);
 				// let's keep everything in between the current index and the
@@ -415,6 +419,10 @@ public class JaxrsEndpoint implements IJaxrsEndpoint {
 		final StringBuilder pathTemplateBuilder = new StringBuilder();
 		int index = 0;
 		if (resourceMethod.getPathTemplate() != null) {
+			// make sure the path template starts with a '/'. 
+			if(!resourceMethod.getPathTemplate().startsWith("/")) {
+				pathTemplateBuilder.append('/');
+			}
 			while (index < resourceMethod.getPathTemplate().length()) {
 				final int beginIndex = resourceMethod.getPathTemplate().indexOf('{', index);
 				final int endIndex = resourceMethod.getPathTemplate().indexOf('}', beginIndex + 1);

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/PurchaseOrderResource.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/PurchaseOrderResource.java
@@ -7,6 +7,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.MatrixParam; // DO NOT REMOVE
 
 import org.jboss.tools.ws.jaxrs.sample.domain.PurchaseOrder;
 
@@ -20,5 +21,7 @@ public class PurchaseOrderResource {
 	public PurchaseOrder getOrder(@PathParam("id") Integer id, @Context UriInfo uriInfo) {
 		return null;
 	}
+	
+	//PLACEHOLDER
 
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpointTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpointTestCase.java
@@ -182,6 +182,22 @@ public class JaxrsEndpointTestCase {
 	}
 
 	@Test
+	// see JBIDE-16476
+	public void shouldDisplayEndpointWithMatrixParamsOnly() throws CoreException {
+		// pre-conditions
+		final String typeName = "org.jboss.tools.ws.jaxrs.sample.services.PurchaseOrderResource";
+		final IType resourceType = metamodelMonitor.resolveType(typeName);
+		ResourcesUtils.replaceFirstOccurrenceOfCode(resourceType, "//PLACEHOLDER", "@GET public void getAll(@MatrixParam(\"author\") java.lang.Long param1, @MatrixParam(\"country\") java.lang.Integer param2) {}", PRIMARY_COPY);
+		final IMethod method = metamodelMonitor.resolveMethod(resourceType, "getAll");
+		final IJaxrsElement resourceMethod = (IJaxrsElement) metamodel.findElement(method);
+		// operation
+		final JaxrsEndpoint endpoint = metamodel.findEndpoints(resourceMethod).get(0);
+		final String uriPathTemplate = endpoint.getUriPathTemplate();
+		// verifications
+		assertThat(uriPathTemplate, equalTo("/hello/orders;author={Long};country={Integer}"));
+	}
+	
+	@Test
 	public void shouldDisplayEndpointWithTypePathUnboundOnMethodParam() throws CoreException {
 		// pre-conditions
 		final String typeName = "org.jboss.tools.ws.jaxrs.sample.services.BarResource";


### PR DESCRIPTION
Remove the '/' that was always included before the resource method URL Path fragment, even
when it was not necessary. It is now only included if the Resource Method has an @Path annotation.
Added a JUnit test to cover the bug.
