### PR TITLE
JBIDE-17296 - Missing warning decorator on the "JAX-RS Web Services" node when no application is defined

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/AbstractJaxrsBaseElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/AbstractJaxrsBaseElement.java
@@ -62,7 +62,6 @@ public abstract class AbstractJaxrsBaseElement implements IJaxrsElement {
 	 * @throws CoreException
 	 */
 	public void registerMarker(final IMarker marker) {
-		//metamodel.registerMarker(marker);
 		this.problemLevel = Math.max(this.problemLevel, marker.getAttribute(IMarker.SEVERITY, 0));
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -211,6 +211,19 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 		}
 		return globalLevel;
 	}
+	
+	/**
+	 * Registers a marker (from the underlying {@link IResource}) and sets the
+	 * problem level on this element. If this element already has a problem
+	 * level, the highest value is kept.
+	 * 
+	 * @param marker: the marker that has been added to the underlying resource.
+	 *            
+	 * @throws CoreException
+	 */
+	public void registerMarker(final IMarker marker) {
+		this.problemLevel = Math.max(this.problemLevel, marker.getAttribute(IMarker.SEVERITY, 0));
+	}
 
 	/**
 	 * Preload the HttpMethods collection with 6 items from the specification:
@@ -904,6 +917,13 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	@Override
 	public List<IJaxrsElement> getAllElements() {
 		return new ArrayList<IJaxrsElement>(elements.values());
+	}
+	
+	/**
+	 * @return {@code true} if the metamodel has {@link IJaxrsElement}s, {@code  false} otherwise.
+	 */
+	public boolean hasElements() {
+		return this.elements.size() > 0;
 	}
 
 	/**
@@ -1603,7 +1623,5 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 				.append(" HttpMethods, ").append(findAllResources().size()).append(" Resources and ")
 				.append(getAllEndpoints().size()).append(" Endpoints.").toString();
 	}
-
-	
 
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
@@ -181,6 +181,7 @@ public class UriPathTemplateCategory implements ITreeContentProvider {
 		try {
 			final IJaxrsMetamodel metamodel= JaxrsMetamodelLocator.get(project);
 			if (metamodel != null) {
+				level = metamodel.getProblemLevel();
 				for (IJaxrsEndpoint endpoint : metamodel.getAllEndpoints()) {
 					level = Math.max(level, endpoint.getProblemLevel());
 				}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidator.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidator.java
@@ -556,7 +556,7 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 		final IMarker marker = addProblem(message, preferenceKey, messageArguments, 0, 0, project);
 		if (marker != null) {
 			marker.setAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, preferenceKey);
-			// metamodel.registerMarker(marker);
+			metamodel.registerMarker(marker);
 		}
 		return marker;
 	}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidatorDelegate.java
@@ -52,7 +52,7 @@ public class JaxrsMetamodelValidatorDelegate {
 		metamodel.resetProblemLevel();
 		final List<JaxrsJavaApplication> javaApplications = metamodel.findJavaApplications();
 		final List<JaxrsWebxmlApplication> webxmlApplications = metamodel.findWebxmlApplications();
-		if (javaApplications.isEmpty() && webxmlApplications.isEmpty()) {
+		if (javaApplications.isEmpty() && webxmlApplications.isEmpty() && metamodel.hasElements()) {
 			markerManager.addMarker(metamodel,
 					JaxrsValidationMessages.APPLICATION_NO_OCCURRENCE_FOUND, new String[0], JaxrsPreferences.APPLICATION_NO_OCCURRENCE_FOUND);
 		} else if (javaApplications.size() >= 2 || (javaApplications.size() >= 1 && webxmlApplications.size() >= 1)) {

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsProviderValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsProviderValidatorDelegate.java
@@ -146,7 +146,6 @@ public class JaxrsProviderValidatorDelegate extends AbstractJaxrsElementValidato
 	private void validatePreMatchingOnContainerRequestFilterOnly(final JaxrsProvider provider) throws CoreException {
 		// this validation rule only applies all providers except Container Request Filters.
 		if (provider != null && !provider.getProvidedTypes().containsKey(EnumElementKind.CONTAINER_REQUEST_FILTER)) {
-			
 			final Annotation preMatchingAnntotation = provider.getAnnotation(JaxrsClassnames.PRE_MATCHING);
 			if(preMatchingAnntotation != null) {
 				final ISourceRange nameRange = preMatchingAnntotation.getJavaAnnotation().getNameRange();

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScannerTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScannerTestCase.java
@@ -603,7 +603,7 @@ public class JavaElementDeltaScannerTestCase {
 		// pre-condition
 		IType type = metamodelMonitor.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		// operation
-		IField addedField = createField(type, "private int i", WORKING_COPY);
+		IField addedField = createField(type, "private int i;", WORKING_COPY);
 		// verifications
 		verifyEventNotification(addedField, ADDED, POST_RECONCILE, NO_FLAG, times(1));
 	}
@@ -623,7 +623,7 @@ public class JavaElementDeltaScannerTestCase {
 		// pre-condition
 		IType type = metamodelMonitor.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		// operation
-		IField addedField = createField(type, "@PathParam() private int i", WORKING_COPY);
+		IField addedField = createField(type, "@PathParam() private int i;", WORKING_COPY);
 		// verifications
 		verifyEventNotification(addedField, ADDED, POST_RECONCILE, NO_FLAG, times(1));
 	}
@@ -633,7 +633,7 @@ public class JavaElementDeltaScannerTestCase {
 		// pre-condition
 		IType type = metamodelMonitor.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		// operation
-		IField addedField = createField(type, "@PathParam() private int i", PRIMARY_COPY);
+		IField addedField = createField(type, "@PathParam() private int i;", PRIMARY_COPY);
 		// verifications
 		verifyEventNotification(addedField.getResource(), CHANGED, POST_CHANGE, CONTENT, atLeastOnce());
 	}


### PR DESCRIPTION
"JAX-RS Web Services" node in project explorer shows a "warning" decorator (by default) if no application was defined, unless no JAX-RS element exists in the project.
