### PR TITLE
JBIDE-17276 - JAX-RS Endpoints should not display an error marker when error is on JAX-RS Application

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpoint.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpoint.java
@@ -28,6 +28,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
@@ -617,14 +618,14 @@ public class JaxrsEndpoint implements IJaxrsEndpoint {
 	 */
 	@Override
 	public int getProblemLevel() {
-		int level = 0; // Severity NONE
+		int level = IMarker.SEVERITY_INFO; // Severity NONE
 		for (IJaxrsResourceMethod resourceMethod : getResourceMethods()) {
 			level = Math.max(level, resourceMethod.getProblemLevel());
 		}
-		level = Math.max(level, httpMethod.getProblemLevel());
+		/*level = Math.max(level, httpMethod.getProblemLevel());
 		if(application != null) {
 			level = Math.max(level, application.getProblemLevel());
-		}
+		}*/
 		return level;
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsHttpMethodValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsHttpMethodValidatorTestCase.java
@@ -155,8 +155,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_INVALID_HTTP_METHOD_ANNOTATION_VALUE));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -179,8 +180,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_INVALID_HTTP_METHOD_ANNOTATION_VALUE));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -203,8 +205,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_MISSING_TARGET_ANNOTATION));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -228,8 +231,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_INVALID_TARGET_ANNOTATION_VALUE));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -253,8 +257,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_INVALID_TARGET_ANNOTATION_VALUE));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -277,8 +282,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_MISSING_RETENTION_ANNOTATION));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -302,8 +308,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_INVALID_RETENTION_ANNOTATION_VALUE));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));
@@ -327,8 +334,9 @@ public class JaxrsHttpMethodValidatorTestCase {
 		final IMarker[] markers = findJaxrsMarkers(httpMethod);
 		assertThat(markers.length, equalTo(1));
 		assertThat(markers, hasPreferenceKey(HTTP_METHOD_INVALID_RETENTION_ANNOTATION_VALUE));
+		// associated endpoints don't have the problem, though
 		for(IJaxrsEndpoint endpoint : metamodel.findEndpoints(httpMethod)) {
-			assertThat(endpoint.getProblemLevel(), not(equalTo(0)));
+			assertThat(endpoint.getProblemLevel(), equalTo(0));
 		}
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().size(), is(1));


### PR DESCRIPTION
Error marker is only shown on the "JAX-RS Web Services" node in the Project Explorer, not on all Endpoint child nodes.
