### PR TITLE
JBIDE-17734 - NPE when creating JAX-RS resource using undefined/empty Bean class

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/SourceType.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/SourceType.java
@@ -84,6 +84,20 @@ public class SourceType {
 		return null;
 	}
 
+	/**
+	 * @return {@code true} if the source type exists, false otherwise.
+	 */
+	public boolean exists() {
+		if(this.erasureType == null || !this.erasureType.exists()) {
+			return false;
+		}
+		for(IType typeArg : typeArguments) {
+			if(typeArg == null || !typeArg.exists()) {
+				return false;
+			}
+		}
+		return true;
+	}
 	
 	/**
 	 * The qualified name of the parameter's type, including erasure and type

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsParameterValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsParameterValidatorDelegate.java
@@ -16,9 +16,7 @@ import java.util.Set;
 import java.util.SortedSet;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.Flags;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -52,13 +50,9 @@ public class JaxrsParameterValidatorDelegate {
 	 *         specification, {@code false} otherwise.
 	 * @throws CoreException
 	 */
-	public boolean validate(final SourceType type, final IJavaProject javaProject,
-			final IProgressMonitor progressMonitor) throws CoreException {
+	public boolean validate(final SourceType type) throws CoreException {
 		if (type.isPrimitive()) {
 			return true;
-		}
-		if(type.getErasureType() == null) {
-			return false;
 		}
 		if (validate(type.getErasureType())) {
 			return true;

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourceFieldValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourceFieldValidatorDelegate.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ISourceRange;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsBaseElement;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
@@ -112,8 +111,11 @@ public class JaxrsResourceFieldValidatorDelegate extends AbstractJaxrsElementVal
 		
 		final JaxrsParameterValidatorDelegate parameterValidatorDelegate = new JaxrsParameterValidatorDelegate();
 		final SourceType type = resourceField.getType();
-		final boolean isValid = parameterValidatorDelegate.validate(type, resourceField.getMetamodel()
-				.getJavaProject(), new NullProgressMonitor());
+		// skip if the type does not exist, there will already be a compilation error reported by JDT.
+		if(!type.exists()) {
+			return;
+		}
+		final boolean isValid = parameterValidatorDelegate.validate(type);
 		if (!isValid) {
 			markerManager.addMarker((JaxrsBaseElement)resourceField, resourceField.getJavaElement().getNameRange(),
 					JaxrsValidationMessages.RESOURCE_METHOD_INVALID_ANNOTATED_PARAMETER_TYPE,

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourcePropertyValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourcePropertyValidatorDelegate.java
@@ -15,12 +15,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ISourceRange;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsBaseElement;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
-import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceProperty;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceMethod;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceProperty;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 import org.jboss.tools.ws.jaxrs.core.jdt.SourceType;
@@ -112,8 +111,11 @@ public class JaxrsResourcePropertyValidatorDelegate extends AbstractJaxrsElement
 		
 		final JaxrsParameterValidatorDelegate parameterValidatorDelegate = new JaxrsParameterValidatorDelegate();
 		final SourceType type = resourceProperty.getType();
-		final boolean isValid = parameterValidatorDelegate.validate(type, resourceProperty.getMetamodel()
-				.getJavaProject(), new NullProgressMonitor());
+		// skip if the type does not exist, there will already be a compilation error reported by JDT.
+		if(!type.exists()) {
+			return;
+		}
+		final boolean isValid = parameterValidatorDelegate.validate(type);
 		if (!isValid) {
 			markerManager.addMarker((JaxrsBaseElement)resourceProperty, resourceProperty.getJavaElement().getNameRange(),
 					JaxrsValidationMessages.RESOURCE_METHOD_INVALID_ANNOTATED_PARAMETER_TYPE,

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/resources/BoatResource.txt
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/resources/BoatResource.txt
@@ -13,7 +13,7 @@ public class BoatResource {
 	
 	//@PathParam("type") //property
 	public void setType(String type) {
-	  this.type = type;
+	  //this.type = type;
 	}
 	
 	@GET

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResource20ValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResource20ValidatorTestCase.java
@@ -173,4 +173,65 @@ public class JaxrsResource20ValidatorTestCase {
 		assertThat(markers.length, equalTo(0));
 	}
 	
+	@Test
+	public void shouldNotReportProblemOnMethodParameterWhenBoundToMissingParamAggregator() throws CoreException, ValidationException {
+		final ICompilationUnit boatResourceCompilationUnit = metamodelMonitor.createCompilationUnit("BoatResource.txt",
+				"org.jboss.tools.ws.jaxrs.sample.services", "BoatResource.java");
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@Path(\"{id}\")", "@Path(\"{type}/{id}\")", false);
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@PathParam(\"id\") int id", "@BeanParam BoatParameterAggregator aggregator", false);
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
+		final JaxrsResource boatResource = metamodel.findResource(boatResourceCompilationUnit.findPrimaryType());
+		metamodelMonitor.resetElementChangesNotifications();
+		
+		// operation: validate
+		new JaxrsMetamodelValidator().validate(toSet(boatResource.getResource()), project, validationHelper, context,
+				validatorManager, reporter);
+		
+		// verifications
+		final IMarker[] markers = findJaxrsMarkers(boatResource);
+		assertThat(markers.length, equalTo(1));
+		assertThat(markers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+	}
+
+	@Test
+	public void shouldNotReportProblemOnResourceFieldWhenBoundToMissingParamAggregator() throws CoreException, ValidationException {
+		final ICompilationUnit boatResourceCompilationUnit = metamodelMonitor.createCompilationUnit("BoatResource.txt",
+				"org.jboss.tools.ws.jaxrs.sample.services", "BoatResource.java");
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@Path(\"{id}\")", "@Path(\"{type}/{id}\")", false);
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "private String type;", "private BoatParameterAggregator aggregator", false);
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
+		final JaxrsResource boatResource = metamodel.findResource(boatResourceCompilationUnit.findPrimaryType());
+		metamodelMonitor.resetElementChangesNotifications();
+		
+		// operation: validate
+		new JaxrsMetamodelValidator().validate(toSet(boatResource.getResource()), project, validationHelper, context,
+				validatorManager, reporter);
+		
+		// verifications
+		final IMarker[] markers = findJaxrsMarkers(boatResource);
+		assertThat(markers.length, equalTo(0));
+	}
+	
+	@Test
+	public void shouldNotReportProblemOnResourcePropertyWhenBoundToMissingParamAggregator() throws CoreException, ValidationException {
+		final ICompilationUnit boatResourceCompilationUnit = metamodelMonitor.createCompilationUnit("BoatResource.txt",
+				"org.jboss.tools.ws.jaxrs.sample.services", "BoatResource.java");
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "public void setType(String type)", "public void setType(BoatParameterAggregator aggregator)", false);
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@Path(\"{id}\")", "@Path(\"{type}/{id}\")", false);
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "//@PathParam(\"type\") //property", "@PathParam(\"type\")", false);
+		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@PathParam(\"type\") //field", "", false);
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
+		final JaxrsResource boatResource = metamodel.findResource(boatResourceCompilationUnit.findPrimaryType());
+		metamodelMonitor.resetElementChangesNotifications();
+		
+		// operation: validate
+		new JaxrsMetamodelValidator().validate(toSet(boatResource.getResource()), project, validationHelper, context,
+				validatorManager, reporter);
+		
+		// verifications
+		final IMarker[] markers = findJaxrsMarkers(boatResource);
+		assertThat(markers.length, equalTo(0));
+	}
+	
 }

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourceValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourceValidatorTestCase.java
@@ -677,8 +677,9 @@ public class JaxrsResourceValidatorTestCase {
 				validatorManager, reporter);
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(carResource);
-		assertThat(markers.length, equalTo(6));
-		for (IMarker marker : markers) {
+		// 5 markers: missing import/unknown type does not count
+				assertThat(markers.length, equalTo(5));
+				for (IMarker marker : markers) {
 			assertThat(marker.getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 			assertThat((String) marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
 			assertThat((String) marker.getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE),
@@ -700,7 +701,8 @@ public class JaxrsResourceValidatorTestCase {
 				validatorManager, reporter);
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(truckResource);
-		assertThat(markers.length, equalTo(6));
+		// 5 markers: missing import/unknown type does not count
+		assertThat(markers.length, equalTo(5));
 		for (IMarker marker : markers) {
 			assertThat(marker.getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 			assertThat((String) marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
@@ -723,7 +725,8 @@ public class JaxrsResourceValidatorTestCase {
 				validatorManager, reporter);
 		// validation
 		final IMarker[] markers = findJaxrsMarkers(truckResource);
-		assertThat(markers.length, equalTo(6));
+		// 5 markers: missing import/unknown type does not count
+		assertThat(markers.length, equalTo(5));
 		for (IMarker marker : markers) {
 			assertThat(marker.getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 			assertThat((String) marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
@@ -749,8 +752,9 @@ public class JaxrsResourceValidatorTestCase {
 		
 		// validation 1: the JAX-RS resource methods have errors
 		final IMarker[] markers = findJaxrsMarkers(truckResource);
-		assertThat(markers.length, equalTo(6));
-		for (IMarker marker : markers) {
+		// 5 markers: missing import/unknown type does not count
+				assertThat(markers.length, equalTo(5));
+				for (IMarker marker : markers) {
 			assertThat(marker.getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 			assertThat((String) marker.getType(), equalTo(JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID));
 			assertThat((String) marker.getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE),


### PR DESCRIPTION
Fixed, for undefined type on method parameters, resource fields and resource properties
