### PR TITLE
JBIDE-17747 - Unable to complete the JAX-RS Resource Creation Wizard

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsApplicationCreationWizardPage.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsApplicationCreationWizardPage.java
@@ -297,6 +297,9 @@ public class JaxrsApplicationCreationWizardPage extends NewClassWizardPage {
 			final IStatus[] status = new IStatus[] { new Status(IStatus.WARNING, JBossJaxrsUIPlugin.PLUGIN_ID,
 					JaxrsApplicationCreationMessages.JaxrsApplicationCreationWizardPage_SkipApplicationCreationWarning) };
 			updateStatus(status);
+		} else if (applicationMode == SKIP_APPLICATION && this.applicationAlreadyExists) {
+			final IStatus[] status = new IStatus[] { new Status(IStatus.WARNING, JBossJaxrsUIPlugin.PLUGIN_ID, "")};
+			updateStatus(status);
 		}
 	}
 


### PR DESCRIPTION
Setting the status to 'OK' when the selected option is 'skip' and application already exists.
