### PR TITLE
JBIDE-17078 - JAX-RS Problems doesn't appears after the JAX-RS Support is activated

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/configuration/ProjectBuilderUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/configuration/ProjectBuilderUtils.java
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.CoreException;
  */
 public final class ProjectBuilderUtils {
 
-	private static final String VALIDATOR_BUILDER_ID = "org.eclipse.wst.validation.validationbuilder";
+	public static final String VALIDATOR_BUILDER_ID = "org.eclipse.wst.validation.validationbuilder";
 	
 	/** Hidden constructor of the utility method. Prevents instantiation. */
 	private ProjectBuilderUtils() {
@@ -72,20 +72,25 @@ public final class ProjectBuilderUtils {
 			return false;
 		}
 		// prepare a long array to store the JAX-RS builder id
-		final ICommand command = desc.newCommand();
-		command.setBuilderName(builderId);
-		final ICommand[] newCommands = new ICommand[commands.length + 1];
+		final ICommand jaxrsBuilderCommand = desc.newCommand();
+		jaxrsBuilderCommand.setBuilderName(builderId);
 		final int validatorBuilderIdIndex = locatorValidatorBuilderId(commands);
 		if(validatorBuilderIdIndex == -1) {
+			final ICommand[] newCommands = new ICommand[commands.length + 2];
 			System.arraycopy(commands, 0, newCommands, 0, commands.length);
-			newCommands[newCommands.length - 1] = command;
+			newCommands[newCommands.length - 2] = jaxrsBuilderCommand;
+			final ICommand validationBuilderCommand = desc.newCommand();
+			validationBuilderCommand.setBuilderName(VALIDATOR_BUILDER_ID);
+			newCommands[newCommands.length - 1] = validationBuilderCommand;
+			desc.setBuildSpec(newCommands);
 		} else {
+			final ICommand[] newCommands = new ICommand[commands.length + 1];
 			System.arraycopy(commands, 0, newCommands, 0, validatorBuilderIdIndex);
 			System.arraycopy(commands, validatorBuilderIdIndex, newCommands, validatorBuilderIdIndex + 1,
 					commands.length - validatorBuilderIdIndex);
-			newCommands[validatorBuilderIdIndex] = command;
+			newCommands[validatorBuilderIdIndex] = jaxrsBuilderCommand;
+			desc.setBuildSpec(newCommands);
 		}
-		desc.setBuildSpec(newCommands);
 		project.setDescription(desc, null);
 		return true;
 	}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidator.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidator.java
@@ -145,7 +145,9 @@ public class JaxrsMetamodelValidator extends TempMarkerManager implements IValid
 		final long startTime = System.currentTimeMillis();
 		init(project, validationHelper, context, manager, reporter);
 		try {
-			if (!changedFiles.isEmpty()) {
+			if(changedFiles.size() == 1 && changedFiles.contains(project.findMember(".project"))) {
+				validateAll(project, validationHelper, context, manager, reporter);
+			} else if (!changedFiles.isEmpty()) {
 				Logger.debug("*** Validating project {} after files {} changed... ***", project.getName(),
 						changedFiles.toString());
 				final JaxrsMetamodel metamodel = JaxrsMetamodelLocator.get(project);

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/.project
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject/.project
@@ -15,7 +15,6 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<!-- PLACEHOLDER -->
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/configuration/ProjectBuilderUtilsTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/configuration/ProjectBuilderUtilsTestCase.java
@@ -72,8 +72,10 @@ public class ProjectBuilderUtilsTestCase {
 	}
 
 	@Test
-	public void shouldInstallAndUninstallProjectBuilder() throws Exception {
+	public void shouldInstallAndUninstallProjectBuilderWithValidationBuilderMissing() throws Exception {
 		// pre-conditions
+		Assert.assertFalse("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), ProjectBuilderUtils.VALIDATOR_BUILDER_ID));
 		ProjectBuilderUtils.uninstallProjectBuilder(projectMonitor.getProject(), BUILDER_ID);
 		Assert.assertFalse("Wrong result",
 				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), BUILDER_ID));
@@ -83,6 +85,31 @@ public class ProjectBuilderUtilsTestCase {
 				ProjectBuilderUtils.installProjectBuilder(projectMonitor.getProject(), BUILDER_ID));
 		Assert.assertTrue("Wrong result",
 				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertTrue("Wrong result",
+				ProjectBuilderUtils.uninstallProjectBuilder(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertFalse("Wrong result",
+				ProjectBuilderUtils.uninstallProjectBuilder(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertFalse("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), BUILDER_ID));
+	}
+
+	@Test
+	public void shouldInstallAndUninstallProjectBuilderWithValidationBuilderAlreadyInstalled() throws Exception {
+		// pre-conditions
+		projectMonitor.replaceDotProjectFileWith("dotProject.txt");
+		Assert.assertTrue("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), ProjectBuilderUtils.VALIDATOR_BUILDER_ID));
+		ProjectBuilderUtils.uninstallProjectBuilder(projectMonitor.getProject(), BUILDER_ID);
+		Assert.assertFalse("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertTrue("Wrong result",
+				ProjectBuilderUtils.installProjectBuilder(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertFalse("Wrong result",
+				ProjectBuilderUtils.installProjectBuilder(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertTrue("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), BUILDER_ID));
+		Assert.assertTrue("Wrong result",
+				ProjectBuilderUtils.isProjectBuilderInstalled(projectMonitor.getProject(), ProjectBuilderUtils.VALIDATOR_BUILDER_ID));
 		Assert.assertTrue("Wrong result",
 				ProjectBuilderUtils.uninstallProjectBuilder(projectMonitor.getProject(), BUILDER_ID));
 		Assert.assertFalse("Wrong result",
@@ -124,7 +151,7 @@ public class ProjectBuilderUtilsTestCase {
 		int p = ProjectBuilderUtils.getBuilderPosition(projectMonitor.getProject(), BUILDER_ID);
 		assertThat(p, equalTo(2));
 		final String[] names = getCommandNames(projectMonitor.getProject());
-		assertThat(names.length, equalTo(3));
+		assertThat(names.length, equalTo(4));
 		for(int i = 0; i < names.length; i++) {
 			assertThat(names[i], notNullValue());
 		}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.jboss.tools.ws.jaxrs.core.configuration.ProjectBuilderUtils;
 import org.jboss.tools.ws.jaxrs.core.configuration.ProjectNatureUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.JavaElementChangedEvent;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsElementFactory;
@@ -239,6 +240,8 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsE
 	 */
 	public JaxrsMetamodel buildMetamodel() throws CoreException, OperationCanceledException, InterruptedException {
 		ProjectNatureUtils.installProjectNature(getProject(), ProjectNatureUtils.JAXRS_NATURE_ID);
+		// remove the validation builder to avoid blocking during tests
+		ProjectBuilderUtils.uninstallProjectBuilder(getProject(), ProjectBuilderUtils.VALIDATOR_BUILDER_ID);
 		buildProject();		
 		return this.metamodel;
 	}

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsApplicationValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsApplicationValidatorTestCase.java
@@ -717,7 +717,7 @@ public class JaxrsApplicationValidatorTestCase {
 		deleteJaxrsMarkers(metamodel);
 		metamodelMonitor.resetElementChangesNotifications();
 		// operation
-		new JaxrsMetamodelValidator().validate(toSet(project.findMember(".project")), project, validationHelper,
+		new JaxrsMetamodelValidator().validate(toSet(project.findMember(".classpath")), project, validationHelper,
 				context, validatorManager, reporter);
 		// validation: validation did not occur on JAX-RS applications.
 		final IMarker[] markers = findJaxrsMarkers(project);


### PR DESCRIPTION
Add the WST validator if missing in the project configuration when adding the JAX-RS nature
Perform a full validation when the '.project' file alone changed.
