### PR TITLE
JBIDE-18090 - Wrong JAX-RS Filter/Annotation binding problem report

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsJavaApplicationValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsJavaApplicationValidatorDelegate.java
@@ -12,7 +12,7 @@ package org.jboss.tools.ws.jaxrs.ui.internal.validation;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
+import java.util.Map.Entry;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ISourceRange;
@@ -112,23 +112,26 @@ public class JaxrsJavaApplicationValidatorDelegate extends AbstractJaxrsElementV
 			return;
 		}
 		final JaxrsMetamodel metamodel = javaApplication.getMetamodel();
-		// take the first NameBinding annotation and look for Providers that
+		// take each NameBinding annotation and look for Providers that
 		// have this annotation, too
-		final String firstNameBindingAnnotationClassName = nameBindingAnnotations.keySet().iterator().next();
-		final Set<String> allBindingAnnotationNames = nameBindingAnnotations.keySet();
-		final Collection<IJaxrsProvider> annotatedProviders = metamodel
-				.findProvidersByAnnotation(firstNameBindingAnnotationClassName);
-		for (IJaxrsProvider provider : annotatedProviders) {
-			if (provider.getNameBindingAnnotations().keySet().equals(allBindingAnnotationNames)) {
-				// provider is valid, at least one method has all those bindings
-				return;
+		annotations_loop:
+		for(Entry<String, Annotation> entry : nameBindingAnnotations.entrySet()) {
+			final String nameBindingAnnotationClassName = entry.getKey();
+			final Collection<IJaxrsProvider> annotatedProviders = metamodel
+					.findProvidersByAnnotation(nameBindingAnnotationClassName);
+			// if provider binding annotation(s) match the application binding annotations
+			for (IJaxrsProvider provider : annotatedProviders) {
+				if (javaApplication.getNameBindingAnnotations().keySet().containsAll(provider.getNameBindingAnnotations().keySet())) {
+					// provider is valid, at least one method has all those bindings
+					continue annotations_loop;
+				}
 			}
+			// otherwise, add a problem marker
+			final ISourceRange nameRange = entry.getValue().getJavaAnnotation().getNameRange();
+			markerManager.addMarker(javaApplication, nameRange, JaxrsValidationMessages.PROVIDER_MISSING_BINDING, new String[]{nameBindingAnnotationClassName},
+					JaxrsPreferences.PROVIDER_MISSING_BINDING);
+			
 		}
-		// otherwise, add a problem marker
-		final ISourceRange nameRange = nameBindingAnnotations.get(firstNameBindingAnnotationClassName)
-				.getJavaAnnotation().getNameRange();
-		markerManager.addMarker(javaApplication, nameRange, JaxrsValidationMessages.PROVIDER_MISSING_BINDING, new String[]{firstNameBindingAnnotationClassName},
-				JaxrsPreferences.PROVIDER_MISSING_BINDING);
 	}
 
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsProviderValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsProviderValidatorDelegate.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaApplication;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsNameBinding;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsProvider;
@@ -73,9 +74,9 @@ public class JaxrsProviderValidatorDelegate extends AbstractJaxrsElementValidato
 	}
 
 	/**
-	 * Validates that at least one {@link JaxrsResource} or
-	 * {@link JaxrsResourceMethod} is annotated with *all the same*
-	 * {@link JaxrsNameBinding} annotation(s) than this provider
+	 * Validates that at least one {@link JaxrsResource}
+	 * {@link JaxrsResourceMethod} or {@link JaxrsJavaApplication} contains all the 
+	 * {@link JaxrsNameBinding} annotation(s) declared on this provider
 	 * 
 	 * @param provider
 	 *            the provider to validate
@@ -95,21 +96,21 @@ public class JaxrsProviderValidatorDelegate extends AbstractJaxrsElementValidato
 		final Set<String> allBindingAnnotationNames = nameBindingAnnotations.keySet();
 		final Collection<IJaxrsResourceMethod> annotatedResourceMethods = metamodel.findResourceMethodsByAnnotation(firstNameBindingAnnotationClassName);
 		for(IJaxrsResourceMethod resourceMethod : annotatedResourceMethods) {
-			if(resourceMethod.getNameBindingAnnotations().keySet().equals(allBindingAnnotationNames)) {
+			if(resourceMethod.getNameBindingAnnotations().keySet().containsAll(allBindingAnnotationNames)) {
 				// provider is valid, at least one method has all those bindings
 				return;
 			}
 		}
 		final Collection<IJaxrsResource> annotatedResources = metamodel.findResourcesByAnnotation(firstNameBindingAnnotationClassName);
 		for(IJaxrsResource resource : annotatedResources) {
-			if(resource.getNameBindingAnnotations().keySet().equals(allBindingAnnotationNames)) {
+			if(resource.getNameBindingAnnotations().keySet().containsAll(allBindingAnnotationNames)) {
 				// provider is valid, at least one method has all those bindings
 				return;
 			}
 		}
 		final Collection<IJaxrsJavaApplication> annotatedApplications = metamodel.findApplicationsByAnnotation(firstNameBindingAnnotationClassName);
 		for(IJaxrsJavaApplication application : annotatedApplications) {
-			if(application.getNameBindingAnnotations().keySet().equals(allBindingAnnotationNames)) {
+			if(application.getNameBindingAnnotations().keySet().containsAll(allBindingAnnotationNames)) {
 				// provider is valid, at least one method has all those bindings
 				return;
 			}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsValidationMessages.properties
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsValidationMessages.properties
@@ -40,5 +40,5 @@ PROVIDER_DUPLICATE_MESSAGE_BODY_READER=This Message Body Reader collides with ''
 PROVIDER_DUPLICATE_MESSAGE_BODY_WRITER=This Message Body Writer collides with ''{0}''.
 PROVIDER_DUPLICATE_EXCEPTION_MAPPER=This Exception Mapper collides with ''{0}''.
 PROVIDER_INVALID_PRE_MATCHING_ANNOTATION_USAGE=The @PreMatching annotation is only allowed on subclasses of javax.ws.rs.container.ContainerRequestFilter.
-PROVIDER_MISSING_BINDING=There is no Filter or Interceptor annotated with such Name Binding(s).
-PROVIDER_UNUSED_BINDING=There is no Resource or Resource Method annotated with such Name Binding(s).
+PROVIDER_MISSING_BINDING=There is no JAX-RS filter or interceptor with this name binding annotation.
+PROVIDER_UNUSED_BINDING=There is no JAX-RS application, resource or resource method with this name binding annotation.

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/navigation/JaxrsNameBindingAnnotationHyperlink.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/navigation/JaxrsNameBindingAnnotationHyperlink.java
@@ -57,7 +57,7 @@ public class JaxrsNameBindingAnnotationHyperlink implements IHyperlink {
 	 */
 	@Override
 	public String getHyperlinkText() {
-		return "Jump to " + getDisplayNameText(targetElement);
+		return "Open " + getDisplayNameText(targetElement);
 	}
 
 	public static String getDisplayNameText(final IJaxrsJavaElement element) {

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject2/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/CustomerResource.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject2/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/CustomerResource.java
@@ -23,7 +23,8 @@ import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.jboss.tools.ws.jaxrs.sample.domain.Customer;
-import org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding;
+import org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding; // do not remove: used for tests
+import org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding; // do not remove: used for tests
 
 @Encoded
 @Path(value=CustomerResource.URI_BASE) // leave as-is: this form is required by a test

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject2/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/RestApplication.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/projects/org.jboss.tools.ws.jaxrs.tests.sampleproject2/src/main/java/org/jboss/tools/ws/jaxrs/sample/services/RestApplication.java
@@ -3,6 +3,7 @@ package org.jboss.tools.ws.jaxrs.sample.services;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 import org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding; // do not remove
+import org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding; // do not remove
 
 @SuppressWarnings("unused")
 @ApplicationPath("/app")

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestProjectMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestProjectMonitor.java
@@ -397,4 +397,5 @@ public class TestProjectMonitor extends ExternalResource {
 		return WtpUtils.getWebDeploymentDescriptor(project);
 	}
 
+	
 }

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ProviderValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ProviderValidatorTestCase.java
@@ -9,7 +9,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.jboss.tools.ws.jaxrs.core.junitrules.ResourcesUtils.replaceFirstOccurrenceOfCode;
 import static org.jboss.tools.ws.jaxrs.ui.internal.validation.ValidationUtils.deleteJaxrsMarkers;
 import static org.jboss.tools.ws.jaxrs.ui.internal.validation.ValidationUtils.findJaxrsMarkers;
+import static org.jboss.tools.ws.jaxrs.ui.internal.validation.ValidationUtils.matchesLocation;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
@@ -34,6 +36,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsProvider;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceMethod;
+import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
 import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
@@ -68,7 +71,7 @@ public class Jaxrs20ProviderValidatorTestCase {
 	private JaxrsMetamodel metamodel = null;
 	private IProject project = null;
 	private IJavaProject javaProject = null;
-	
+
 	@Rule
 	public TestWatcher watcher = new TestWatcher();
 
@@ -95,7 +98,7 @@ public class Jaxrs20ProviderValidatorTestCase {
 				EnumElementCategory.PROVIDER);
 		deleteJaxrsMarkers(project);
 		metamodelMonitor.resetElementChangesNotifications();
-		
+
 		// operation
 		new JaxrsMetamodelValidator().validateAll(project, validationHelper, context, validatorManager, reporter);
 		// validation: no need to report further problems, JDT Validation
@@ -117,7 +120,7 @@ public class Jaxrs20ProviderValidatorTestCase {
 				EnumElementCategory.PROVIDER);
 		deleteJaxrsMarkers(project);
 		metamodelMonitor.resetElementChangesNotifications();
-		
+
 		// operation
 		new JaxrsMetamodelValidator().validateAll(project, validationHelper, context, validatorManager, reporter);
 		// validation: no need to report further problems, JDT Validation
@@ -133,7 +136,8 @@ public class Jaxrs20ProviderValidatorTestCase {
 	@Test
 	public void shouldNotReportProblemOnReaderInterceptor() throws CoreException, ValidationException {
 		// preconditions
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomReaderInterceptor");
+		metamodelMonitor
+				.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomReaderInterceptor");
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
 				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomReaderInterceptor",
 				EnumElementCategory.PROVIDER);
@@ -155,7 +159,8 @@ public class Jaxrs20ProviderValidatorTestCase {
 	@Test
 	public void shouldNotReportProblemOnWriterInterceptor() throws CoreException, ValidationException {
 		// preconditions
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomWriterInterceptor");
+		metamodelMonitor
+				.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomWriterInterceptor");
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
 				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomWriterInterceptor",
 				EnumElementCategory.PROVIDER);
@@ -175,20 +180,22 @@ public class Jaxrs20ProviderValidatorTestCase {
 	}
 
 	@Test
-	public void shouldReportWarningWhenPreMatchingAnnotationUsedOnAnotherProvider() throws CoreException,
+	public void shouldReportWarningWhenPreMatchingAnnotationUsedOnWrongKindOfProvider() throws CoreException,
 			ValidationException {
 		// preconditions
 		final IType providerType = replaceFirstOccurrenceOfCode(
 				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomWriterInterceptor", javaProject,
 				"@Provider", "@Provider @PreMatching", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomWriterInterceptor");
-		final JaxrsProvider provider = (JaxrsProvider) metamodel
-				.findElement(providerType.getFullyQualifiedName(), EnumElementCategory.PROVIDER);
+		metamodelMonitor
+				.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomWriterInterceptor");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType.getFullyQualifiedName(),
+				EnumElementCategory.PROVIDER);
 		deleteJaxrsMarkers(project);
 		metamodelMonitor.resetElementChangesNotifications();
 
 		// operation
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
 		// validation: no need to report further problems, JDT Validation
 		// already reports compilation errors
 		final IMarker[] markers = findJaxrsMarkers(provider);
@@ -202,26 +209,74 @@ public class Jaxrs20ProviderValidatorTestCase {
 		assertThat(markers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 	}
 
+	// **************************************************************************************************************************
+	// Testing the validation of binding provider with a resource, a resource
+	// method or an application using 1 or more name annotations
+	// **************************************************************************************************************************
+
 	@Test
-	public void shouldNotReportProblemWhenApplicationHasCustomNameBindingAnnotation() throws CoreException,
+	public void shouldNotReportProblemWhenMissingNameBindingAnnotationOnMetaAnnotation() throws CoreException,
 			ValidationException {
-		// pre-condition: remove custom Name Binding meta-annotation on
-		// CustomInterceptorBinding annotation
-		replaceFirstOccurrenceOfCode(
-				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject,
-				"public class", "@CustomInterceptorBinding public class", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.RestApplication");
-		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+		// pre-condition: remove @NameBinding annotation on
+		// CustomInterceptorBinding meta-annotation -> ie, there is NO binding !
+		final IType nameBindingType = replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", javaProject,
+				"@NameBinding", "", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
 				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
-				EnumElementCategory.PROVIDER);
-		final IJaxrsApplication application = (IJaxrsApplication) metamodel.findElement("org.jboss.tools.ws.jaxrs.sample.services.RestApplication", EnumElementCategory.APPLICATION);
-		
+				"org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final IType gameResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
 		deleteJaxrsMarkers(project);
 		metamodelMonitor.resetElementChangesNotifications();
 
-		// operation: validate the resource
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project, validationHelper, context, validatorManager, reporter);
-		// verification: no error on RestApplication: there's a Filter/Interceptor
+		// operation: validate the *nameBinding* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(nameBindingType.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: there's no problem, the Interceptor became a Global
+		// Interceptor ;-)
+		final IMarker[] markers = nameBindingType.getResource().findMarkers(
+				JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID, true, IResource.DEPTH_INFINITE);
+		for (IMarker marker : markers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(markers.length, equalTo(0));
+		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldNotReportProblemWhenApplicationBoundToProviderWithSingleAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition: remove custom Name Binding meta-annotation on
+		// CustomInterceptorBinding annotation
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject,
+				"public class", "@CustomInterceptorBinding public class", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IJaxrsApplication application = (IJaxrsApplication) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", EnumElementCategory.APPLICATION);
+
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *application* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(application.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: no error on RestApplication: there's a
+		// Filter/Interceptor
 		// with such a Name Binding
 		final IMarker[] applicationMarkers = findJaxrsMarkers(application);
 		for (IMarker marker : applicationMarkers) {
@@ -240,109 +295,103 @@ public class Jaxrs20ProviderValidatorTestCase {
 	}
 
 	@Test
-	public void shouldNotReportProblemWhenResourceMethodHasCustomNameBindingAnnotation() throws CoreException,
-			ValidationException {
-		// pre-condition 
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
-		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
-				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
-				EnumElementCategory.PROVIDER);
-		final IType customerResourceType = metamodelMonitor
-				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
-		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(customerResourceType);
-		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResourceType, "getCustomer");
-		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
-				getCustomerMethod.getHandleIdentifier());
-		deleteJaxrsMarkers(project);
-		metamodelMonitor.resetElementChangesNotifications();
-
-		// operation: validate the resource
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project, validationHelper, context, validatorManager, reporter);
-		// verification
-		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
-		for (IMarker marker : providerMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(providerMarkers.length, equalTo(0));
-		final IMarker[] resourceMarkers = findJaxrsMarkers(customerResourceMethod);
-		for (IMarker marker : resourceMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(resourceMarkers.length, equalTo(0));
-	}
-
-	@Test
-	public void shouldNotReportProblemWhenResourceHasCustomNameBindingAnnotation() throws CoreException,
-			ValidationException {
-		// pre-condition
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.GameResource");
-		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
-				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
-				EnumElementCategory.PROVIDER);
-		final IType gameResourceType = metamodelMonitor
-				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
-		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
-		deleteJaxrsMarkers(project);
-		metamodelMonitor.resetElementChangesNotifications();
-
-		// operation: validate the resource
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project, validationHelper, context, validatorManager, reporter);
-		// verification
-		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
-		for (IMarker marker : providerMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(providerMarkers.length, equalTo(0));
-		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
-		for (IMarker marker : resourceMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(resourceMarkers.length, equalTo(0));
-	}
-
-	@Test
-	public void shouldNotReportProblemWhenMissingNameBindingAnnotationOnMetaAnnotation() throws CoreException,
-			ValidationException {
-		// pre-condition: remove @NameBinding annotation on
-		// CustomInterceptorBinding meta-annotation
-		final IType nameBindingType = replaceFirstOccurrenceOfCode(
-				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", javaProject,
-				"@NameBinding", "", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.GameResource");
-		final IType gameResourceType = metamodelMonitor
-				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
-		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
-		deleteJaxrsMarkers(project);
-		metamodelMonitor.resetElementChangesNotifications();
-
-		// operation: validate the resource
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(nameBindingType.getResource()), project, validationHelper, context, validatorManager, reporter);
-		// verification: there's no problem, the Interceptor became a Global
-		// Interceptor ;-)
-		final IMarker[] markers = nameBindingType.getResource().findMarkers(
-				JaxrsMetamodelValidator.JAXRS_PROBLEM_MARKER_ID, true, IResource.DEPTH_INFINITE); 
-		for (IMarker marker : markers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(markers.length, equalTo(0));
-		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
-		for (IMarker marker : resourceMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(resourceMarkers.length, equalTo(0));
-	}
-
-	@Test
-	public void shouldReportProblemOnApplicationWhenNoProviderHasNameBindingAnnotation() throws CoreException,
+	public void shouldNotReportProblemWhenApplicationBoundToProviderWithTwoAnnotations() throws CoreException,
 			ValidationException {
 		// pre-condition: remove custom Name Binding meta-annotation on
 		// CustomInterceptorBinding annotation
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject,
+				"public class", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding public class", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IJaxrsApplication application = (IJaxrsApplication) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", EnumElementCategory.APPLICATION);
+
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: no error on RestApplication: there's a
+		// Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] applicationMarkers = findJaxrsMarkers(application);
+		for (IMarker marker : applicationMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(applicationMarkers.length, equalTo(0));
+		// verification: no error on Provider: there's an Application
+		// with such a Name Binding
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldReportProblemOnApplicationWhenMissingBindingAnnotationToProvider() throws CoreException,
+			ValidationException {
+		// pre-condition: remove custom Name Binding meta-annotation on
+		// CustomInterceptorBinding annotation
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject,
+				"public class", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding public class", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IJaxrsApplication application = (IJaxrsApplication) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", EnumElementCategory.APPLICATION);
+
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: no error on RestApplication: there's a
+		// Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] applicationMarkers = findJaxrsMarkers(application);
+		for (IMarker marker : applicationMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(applicationMarkers.length, equalTo(0));
+		// verification: no error on Provider: there's an Application
+		// with such a Name Binding
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldReportProblemOnApplicationWhenNoProviderMatchesSingleBindingAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition: add @CustomInterceptorBinding annotation on
+		// RestApplication for application-wide binding
+		// but remove the @CustomInterceptorBinding annotation on the
+		// ResponseFilter.
 		final IType applicationType = replaceFirstOccurrenceOfCode(
 				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject, "public class",
 				"@CustomInterceptorBinding public class", false);
@@ -360,60 +409,216 @@ public class Jaxrs20ProviderValidatorTestCase {
 		metamodelMonitor.resetElementChangesNotifications();
 
 		// operation: validate the *provider* that just changed
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(application.getResource(), provider.getResource()), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
 		// verification: error on *RestApplication*: no Filter/Interceptor
 		// with such a Name Binding
-		final IMarker[] markers = findJaxrsMarkers(application);
-		for (IMarker marker : markers) {
+		final IMarker[] applicationMarkers = findJaxrsMarkers(application);
+		for (IMarker marker : applicationMarkers) {
 			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
 					marker.getAttribute(IMarker.MESSAGE));
 		}
-		assertThat(markers.length, equalTo(1));
-		assertThat(markers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+		assertThat(applicationMarkers.length, equalTo(1));
+		assertThat(applicationMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
 				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
-		assertThat(markers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		assertThat(applicationMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		// no problem on the provider, since it has NO binding annotation.
+		assertThat(providerMarkers.length, equalTo(0));
 	}
 
 	@Test
-	public void shouldReportProblemOnResourceMethodWhenNoProviderHasNameBindingAnnotation() throws CoreException,
-			ValidationException {
-		// pre-condition: remove custom Name Binding meta-annotation on
-		// CustomInterceptorBinding annotation
-		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject, "@CustomInterceptorBinding", "", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
-		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+	public void shouldReportProblemOnApplicationWhenDeclaringIncompleteSetOfAnnotationsToBindWithProvider()
+			throws CoreException, ValidationException {
+		// pre-condition: add @CustomInterceptorBinding annotation on
+		// RestApplication for application-wide binding
+		// and add the @AnotherCustomInterceptorBinding annotation on the
+		// ResponseFilter.
+		final IType applicationType = replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject, "public class",
+				"@CustomInterceptorBinding public class", false);
+		final IType providerType = replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
 				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
-				EnumElementCategory.PROVIDER);
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType);
+		final JaxrsJavaApplication application = (JaxrsJavaApplication) metamodel.findElement(applicationType);
 		deleteJaxrsMarkers(project);
 		metamodelMonitor.resetElementChangesNotifications();
 
 		// operation: validate the *provider* that just changed
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project, validationHelper, context, validatorManager, reporter);
-		// verification: error on *Customer Resource Method*: no Filter/Interceptor
-		// with such a Name Binding
-		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
-		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResource.getJavaElement(), "getCustomer");
-		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
-				getCustomerMethod.getHandleIdentifier());
-		final IMarker[] markers = findJaxrsMarkers(customerResourceMethod);
-		for (IMarker marker : markers) {
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *RestApplication*: no Filter/Interceptor
+		// with such a Name Bindings
+		final IMarker[] applicationMarkers = findJaxrsMarkers(application);
+		for (IMarker marker : applicationMarkers) {
 			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
 					marker.getAttribute(IMarker.MESSAGE));
 		}
-		assertThat(markers.length, equalTo(1));
-		assertThat(markers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+		assertThat(applicationMarkers.length, equalTo(1));
+		assertThat(applicationMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
 				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
-		assertThat(markers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		assertThat(applicationMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		// also problem on the provider, since it has no binding with the
+		// application.
+		assertThat(providerMarkers.length, equalTo(1));
+		assertThat(providerMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_UNUSED_BINDING));
+		assertThat(providerMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 	}
 
 	@Test
-	public void shouldReportProblemOnResourceWhenNoProviderHasNameBindingAnnotation() throws CoreException,
+	public void shouldReportProblemOnApplicationWhenNoOtherProviderMatchesSecondBindingAnnotation()
+			throws CoreException, ValidationException {
+		// pre-condition: add @CustomInterceptorBinding and
+		// @AnotherCustomInterceptorBinding annotations on
+		// RestApplication for application-wide binding
+		final IType applicationType = replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication", javaProject, "public class",
+				"@CustomInterceptorBinding @AnotherCustomInterceptorBinding public class", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final JaxrsJavaApplication application = (JaxrsJavaApplication) metamodel.findElement(applicationType);
+		final Annotation anotherCustomInterceptorBindingAnnotation = application
+				.getAnnotation("org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding");
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *application* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(application.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *RestApplication*: no Filter/Interceptor
+		// with such a (second) Name Binding
+		final IMarker[] applicationMarkers = findJaxrsMarkers(application);
+		for (IMarker marker : applicationMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(applicationMarkers.length, equalTo(1));
+		assertThat(applicationMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(applicationMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		assertThat(applicationMarkers[0], matchesLocation(anotherCustomInterceptorBindingAnnotation.getJavaAnnotation()
+				.getNameRange()));
+		// no problem on the provider, since it is already bound with its single
+		// annotation.
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldNotReportProblemWhenResourceBoundToProviderWithSingleAnnotation() throws CoreException,
 			ValidationException {
-		// pre-condition: remove custom Name Binding meta-annotation on
-		// CustomInterceptorBinding annotation
-		final IType providerType = 
-		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject, "@CustomInterceptorBinding", "", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		// pre-condition
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IType gameResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldNotReportProblemWhenResourceBoundToProviderWithTwoAnnotations() throws CoreException,
+			ValidationException {
+		// pre-condition
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.GameResource", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IType gameResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldReportProblemOnResourceWhenNoProviderMatchesSingleBindingAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition
+		final IType providerType = replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.GameResource");
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(providerType);
 		final IType gameResourceType = metamodelMonitor
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
@@ -422,7 +627,8 @@ public class Jaxrs20ProviderValidatorTestCase {
 		metamodelMonitor.resetElementChangesNotifications();
 
 		// operation: validate the *provider* that just changed
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource(), gameResource.getResource()), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
 		// verification: error on *Game Resource*: no Filter/Interceptor
 		// with such a Name Binding
 		final IMarker[] markers = findJaxrsMarkers(gameResource);
@@ -437,21 +643,350 @@ public class Jaxrs20ProviderValidatorTestCase {
 	}
 
 	@Test
-	public void shouldReportProblemWhenNoElementHasNameBindingAnnotation() throws CoreException, ValidationException {
-		// pre-condition: remove custom NameBinding annotation on
-		// CustomerResource method
-		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", javaProject, "@CustomInterceptorBinding", "", false);
-		
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+	public void shouldReportProblemOnResourceWhenNoProviderMatchesSecondBindingAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.GameResource", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.GameResource");
 		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
 				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
 				EnumElementCategory.PROVIDER);
-		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
+		final IType gameResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
+		final Annotation anotherCustomInterceptorBindingAnnotation = gameResource
+				.getAnnotation("org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding");
+
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *gameResource* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(gameResource.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *Game Resource*: no Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(1));
+		assertThat(resourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(resourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		assertThat(resourceMarkers[0], matchesLocation(anotherCustomInterceptorBindingAnnotation.getJavaAnnotation()
+				.getNameRange()));
+		// existing provider is bound, so no problem reported
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldReportProblemOnResourceWhenDeclaringIncompleteSetOfAnnotationsToBindWithProvider()
+			throws CoreException, ValidationException {
+		// pre-condition: add a second binding annotation on the provider only
+		// (missing on 'GameResource')
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IType gameResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.GameResource");
+		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider*
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *Game Resource*: no Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] resourceMarkers = findJaxrsMarkers(gameResource);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(1));
+		assertThat(resourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(resourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		// existing provider is not bound, so a problem is reported, too
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(1));
+		assertThat(resourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(resourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+	}
+
+	@Test
+	public void shouldNotReportProblemWhenResourceMethodBoundToProviderWithSingleAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IType customerResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(customerResourceType);
+		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResourceType, "getCustomer");
+		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
+				getCustomerMethod.getHandleIdentifier());
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider*
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+		final IMarker[] resourceMarkers = findJaxrsMarkers(customerResourceMethod);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldNotReportProblemWhenResourceMethodBoundToProviderWithTwoAnnotations() throws CoreException,
+			ValidationException {
+		// pre-condition
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final IType customerResourceType = metamodelMonitor
+				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(customerResourceType);
+		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResourceType, "getCustomer");
+		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
+				getCustomerMethod.getHandleIdentifier());
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *customerResource* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(customerResource.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+		final IMarker[] resourceMarkers = findJaxrsMarkers(customerResourceMethod);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldReportProblemOnResourceMethodWhenNoProviderMatchesSingleBindingAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition: remove @CustomInterceptorBinding on
+		// CustomResponseFilterWithBinding
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
+		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResource.getJavaElement(),
+				"getCustomer");
+		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
+				getCustomerMethod.getHandleIdentifier());
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *provider* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(provider.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *Customer Resource Method*: no
+		// Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] markers = findJaxrsMarkers(customerResourceMethod);
+		for (IMarker marker : markers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(markers.length, equalTo(1));
+		assertThat(markers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(markers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+	}
+
+	@Test
+	public void shouldReportProblemOnResourceMethodWhenNoProviderMatchesSecondBindingAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition: add @AnotherCustomInterceptorBinding on resource
+		// method but not on any provider
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
+		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResource.getJavaElement(),
+				"getCustomer");
+		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
+				getCustomerMethod.getHandleIdentifier());
+		final Annotation anotherCustomInterceptorBindingAnnotation = customerResourceMethod
+				.getAnnotation("org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding");
+
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *customerResource* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(customerResource.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *Customer Resource Method*: no
+		// Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] resourceMarkers = findJaxrsMarkers(customerResourceMethod);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(1));
+		assertThat(resourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(resourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		assertThat(resourceMarkers[0], matchesLocation(anotherCustomInterceptorBindingAnnotation.getJavaAnnotation()
+				.getNameRange()));
+		// no problem reported on the provider, since it is already bound
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(0));
+	}
+
+	@Test
+	public void shouldReportProblemOnResourceMethodWhenDeclaringIncompleteSetOfAnnotationsToBindWithProvider()
+			throws CoreException, ValidationException {
+		// pre-condition: add @AnotherCustomInterceptorBinding on provider but
+		// not on resource method
+		replaceFirstOccurrenceOfCode(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", javaProject,
+				"@CustomInterceptorBinding", "@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
+		final IMethod getCustomerMethod = metamodelMonitor.resolveMethod(customerResource.getJavaElement(),
+				"getCustomer");
+		final JaxrsResourceMethod customerResourceMethod = customerResource.getMethods().get(
+				getCustomerMethod.getHandleIdentifier());
+		deleteJaxrsMarkers(project);
+		metamodelMonitor.resetElementChangesNotifications();
+
+		// operation: validate the *customerResource* that just changed
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(customerResource.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
+		// verification: error on *Customer Resource Method*: no
+		// Filter/Interceptor
+		// with such a Name Binding
+		final IMarker[] resourceMarkers = findJaxrsMarkers(customerResourceMethod);
+		for (IMarker marker : resourceMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(resourceMarkers.length, equalTo(1));
+		assertThat(resourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(resourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+		// problem also reported on the provider, since it is not bound
+		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
+		for (IMarker marker : providerMarkers) {
+			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
+					marker.getAttribute(IMarker.MESSAGE));
+		}
+		assertThat(providerMarkers.length, equalTo(1));
+		assertThat(resourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
+				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
+		assertThat(resourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
+	}
+
+	@Test
+	public void shouldReportProblemOnProviderWhenNoElementMatchesSingleBindingAnnotation() throws CoreException,
+			ValidationException {
+		// pre-condition: remove binding annotation on the resource method
+		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", javaProject,
+				"@CustomInterceptorBinding", "", false);
+		metamodelMonitor.createElements(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
+				EnumElementCategory.PROVIDER);
+		final JaxrsResource customerResource = (JaxrsResource) metamodel.findElement(
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
 		deleteJaxrsMarkers(project);
 		metamodelMonitor.resetElementChangesNotifications();
 
 		// operation: validate the *customer resource* that just changed
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(customerResource.getResource(), provider.getResource()), project, validationHelper, context, validatorManager, reporter);
+		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(customerResource.getResource()), project,
+				validationHelper, context, validatorManager, reporter);
 		// verification: error on *Provider*: no other element
 		// with such a Name Binding
 		final IMarker[] markers = findJaxrsMarkers(provider);
@@ -465,46 +1000,4 @@ public class Jaxrs20ProviderValidatorTestCase {
 		assertThat(markers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
 	}
 
-	@Test
-	public void shouldReportProblemWhenNoProviderHasAllNameBindingAnnotations() throws CoreException,
-			ValidationException {
-		// pre-condition: add another @NameBinding annotation on the Resource
-		final IType gameResourceType = 
-		replaceFirstOccurrenceOfCode("org.jboss.tools.ws.jaxrs.sample.services.GameResource", javaProject, "@CustomInterceptorBinding",
-				"@CustomInterceptorBinding @AnotherCustomInterceptorBinding", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.interceptors.AnotherCustomInterceptorBinding", "org.jboss.tools.ws.jaxrs.sample.services.GameResource");
-		final JaxrsProvider provider = (JaxrsProvider) metamodel.findElement(
-				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomResponseFilterWithBinding",
-				EnumElementCategory.PROVIDER);
-		final JaxrsResource gameResource = (JaxrsResource) metamodel.findElement(gameResourceType);
-		deleteJaxrsMarkers(project);
-		metamodelMonitor.resetElementChangesNotifications();
-
-		// operation: validate the *Game Resource* that just changed
-		new JaxrsMetamodelValidator().validate(ValidationUtils.toSet(gameResource.getResource(), provider.getResource()), project, validationHelper, context, validatorManager, reporter);
-		// verification: error on Game Resource: no Filter/Interceptor
-		// with the *two* NameBindings
-		final IMarker[] gameResourceMarkers = findJaxrsMarkers(gameResource);
-		for (IMarker marker : gameResourceMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(gameResourceMarkers.length, equalTo(1));
-		assertThat(gameResourceMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
-				equalTo(JaxrsPreferences.PROVIDER_MISSING_BINDING));
-		assertThat(gameResourceMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("'{0}'")));
-		// verification: side effect: error on Provider because no element is
-		// bound to this Name
-		final IMarker[] providerMarkers = findJaxrsMarkers(provider);
-		for (IMarker marker : providerMarkers) {
-			TestLogger.debug("problem at line {}: {}", marker.getAttribute(IMarker.LINE_NUMBER),
-					marker.getAttribute(IMarker.MESSAGE));
-		}
-		assertThat(providerMarkers.length, equalTo(1));
-		assertThat(providerMarkers[0].getAttribute(JaxrsMetamodelValidator.JAXRS_PROBLEM_TYPE, ""),
-				equalTo(JaxrsPreferences.PROVIDER_UNUSED_BINDING));
-		assertThat(providerMarkers[0].getAttribute(IMarker.MESSAGE, ""), not(containsString("{")));
-	}
-	
-	
 }


### PR DESCRIPTION
Also fixed:
JBIDE-18078 - Wrong problem marker on binding annotation
JBIDE-18089 - Edit the JAX-RS binding navigation label, replace 'Jump to' with 'Open'

Added JUnit tests
