### PR TITLE
JBIDE-17178 - Problem with filters and interceptors defined as inner classes

### DIFF
--- a/tests/org.jboss.tools.ws.jaxrs.core.test/resources/ResourceWithInnerProvider.txt
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/resources/ResourceWithInnerProvider.txt
@@ -1,0 +1,30 @@
+package org.jboss.tools.ws.jaxrs.sample.services;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+@Path("/")
+public class RestService {
+	 
+	@GET
+	public Response get() {
+		System.out.println("Just passed in method");
+		return Response.ok().build();
+	}
+	
+	//@Provider
+    public static class AuthorizedResponseFilter implements ContainerResponseFilter {
+		@Override
+		public void filter(ContainerRequestContext arg0,
+				ContainerResponseContext arg1) throws IOException {
+			System.out.println("Just passed in filter");
+		}
+    }
+}

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs11ResourceValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs11ResourceValidatorTestCase.java
@@ -816,9 +816,12 @@ public class Jaxrs11ResourceValidatorTestCase {
 		
 		// verifications
 		final IMessage[] messages = findJaxrsMessages(reporter, boatResource);
-		assertThat(messages.length, equalTo(1));
+		assertThat(messages.length, equalTo(2));
 		assertThat(messages[0].getText(), not(containsString("{")));
 		assertThat((String) messages[0].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+		assertThat(messages[1].getText(), not(containsString("{")));
+		assertThat((String) messages[1].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
 				equalTo(JaxrsPreferences.RESOURCE_ELEMENT_UNBOUND_PATHPARAM_ANNOTATION_VALUE));
 	}
 
@@ -844,9 +847,12 @@ public class Jaxrs11ResourceValidatorTestCase {
 		
 		// verifications 1 : expect 1 problem
 		final IMessage[] messages = findJaxrsMessages(reporter, boatResource);
-		assertThat(messages.length, equalTo(1));
+		assertThat(messages.length, equalTo(2));
 		assertThat(messages[0].getText(), not(containsString("{")));
 		assertThat((String) messages[0].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+		assertThat(messages[1].getText(), not(containsString("{")));
+		assertThat((String) messages[1].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
 				equalTo(JaxrsPreferences.RESOURCE_ELEMENT_UNBOUND_PATHPARAM_ANNOTATION_VALUE));
 
 		// operation 2: fix the value and revalidate
@@ -882,11 +888,14 @@ public class Jaxrs11ResourceValidatorTestCase {
 		
 		// verifications 1 : expect 1 problem
 		final IMessage[] messages = findJaxrsMessages(reporter, boatResource);
-		assertThat(messages.length, equalTo(1));
+		assertThat(messages.length, equalTo(2));
 		assertThat(messages[0].getText(), not(containsString("{")));
 		assertThat((String) messages[0].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+		assertThat(messages[1].getText(), not(containsString("{")));
+		assertThat((String) messages[1].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
 				equalTo(JaxrsPreferences.RESOURCE_ELEMENT_UNBOUND_PATHPARAM_ANNOTATION_VALUE));
-
+		
 		// operation 2: fix the value and revalidate
 		replaceFirstOccurrenceOfCode(boatResource, "@PathParam(\"t\")", "@PathParam(\"type\")", true);
 		document.set(boatResourceCompilationUnit.getSource());
@@ -958,9 +967,12 @@ public class Jaxrs11ResourceValidatorTestCase {
 		
 		// verifications
 		final IMessage[] messages = findJaxrsMessages(reporter, boatResource);
-		assertThat(messages.length, equalTo(1));
+		assertThat(messages.length, equalTo(2));
 		assertThat(messages[0].getText(), not(containsString("{")));
 		assertThat((String) messages[0].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+		assertThat(messages[1].getText(), not(containsString("{")));
+		assertThat((String) messages[1].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
 				equalTo(JaxrsPreferences.RESOURCE_ELEMENT_UNBOUND_PATHPARAM_ANNOTATION_VALUE));
 	}
 	
@@ -988,11 +1000,14 @@ public class Jaxrs11ResourceValidatorTestCase {
 		
 		// verifications 1 : expect 1 problem
 		final IMessage[] messages = findJaxrsMessages(reporter, boatResource);
-		assertThat(messages.length, equalTo(1));
+		assertThat(messages.length, equalTo(2));
 		assertThat(messages[0].getText(), not(containsString("{")));
 		assertThat((String) messages[0].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+		assertThat(messages[1].getText(), not(containsString("{")));
+		assertThat((String) messages[1].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
 				equalTo(JaxrsPreferences.RESOURCE_ELEMENT_UNBOUND_PATHPARAM_ANNOTATION_VALUE));
-		
+
 		// operation 2: fix the value and revalidate
 		replaceFirstOccurrenceOfCode(boatResource, "@PathParam(\"t\")", "@PathParam(\"type\")", true);
 		document.set(boatResourceCompilationUnit.getSource());
@@ -1028,11 +1043,14 @@ public class Jaxrs11ResourceValidatorTestCase {
 		
 		// verifications 1 : expect 1 problem
 		final IMessage[] messages = findJaxrsMessages(reporter, boatResource);
-		assertThat(messages.length, equalTo(1));
+		assertThat(messages.length, equalTo(2));
 		assertThat(messages[0].getText(), not(containsString("{")));
 		assertThat((String) messages[0].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
+				equalTo(JaxrsPreferences.RESOURCE_METHOD_UNBOUND_PATH_ANNOTATION_TEMPLATE_PARAMETER));
+		assertThat(messages[1].getText(), not(containsString("{")));
+		assertThat((String) messages[1].getAttribute(JaxrsMetamodelValidator.PREFERENCE_KEY_ATTRIBUTE_NAME),
 				equalTo(JaxrsPreferences.RESOURCE_ELEMENT_UNBOUND_PATHPARAM_ANNOTATION_VALUE));
-		
+
 		// operation 2: fix the value and revalidate
 		JavaElementsUtils.replaceFirstOccurrenceOfCode(boatResourceCompilationUnit, "@PathParam(\"t\")", "@PathParam(\"type\")", true);
 		document.set(boatResourceCompilationUnit.getSource());


### PR DESCRIPTION
Removed the use of 'dirtyRegions' argument in the as-you-type validator because the given regions
do not match the actual changes...
