### PR TITLE
JBIDE-17949 - Problem with filters and interceptors defined as inner classes

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsBaseElement.java
@@ -90,6 +90,13 @@ public abstract class JaxrsBaseElement implements IJaxrsElement {
 	public final int getMarkerSeverity() {
 		return markerSeverity;
 	}
+	
+	/**
+	 * @return {@code true} if this element has a marker severity > 0, {@code false} otherwise.
+	 */
+	public boolean hasProblem() {
+		return markerSeverity > 0;
+	}
 
 	/** @return the metamodel */
 	public final JaxrsMetamodel getMetamodel() {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsJavaElement.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsJavaElement.java
@@ -54,6 +54,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.CollectionUtils.MapComparison;
@@ -120,7 +121,15 @@ public abstract class JaxrsJavaElement<T extends IMember> extends JaxrsBaseEleme
 		}
 		return this.javaElement.isBinary();
 	}
-
+	
+	/**
+	 * @return {@code true} if the underlying {@link IJavaElement} is not
+	 *         {@code null} and is an {@link IType}, {@code false} otherwise.
+	 */
+	public boolean isBasedOnJavaType() {
+		return this.javaElement != null && this.javaElement.getElementType() == IJavaElement.TYPE;
+	}
+	
 	/**
 	 * @param className
 	 *            the fully qualified name of the annotation to retrieve.

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -622,8 +622,16 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 					// IFields nor IMethods
 					// those elements will internally update their own
 					// children elements based on IMethods and IFields
-					if (element.getJavaElement().getElementType() == IJavaElement.TYPE) {
+					if (element.getJavaElement().getElementType() == IJavaElement.TYPE && javaElement.getElementType() == IJavaElement.TYPE) {
 						element.update(javaElement, ast);
+					} else if(element.getJavaElement().getElementType() == IJavaElement.TYPE && javaElement.getElementType() == IJavaElement.COMPILATION_UNIT) {
+						final ICompilationUnit compilationUnit = (ICompilationUnit) javaElement;
+						final IType type = JdtUtils.resolveType(compilationUnit, element.getJavaElement().getHandleIdentifier());
+						if(type != null) {
+							element.update(type, ast);
+						} else {
+							element.remove(FlagsUtils.computeElementFlags(element));
+						}
 					}
 				}
 			}

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtils.java
@@ -141,13 +141,16 @@ public final class JdtUtils {
 	 * 
 	 * @param type
 	 *            the type to check
-	 * @return true if the type is abstract, false otherwise
+	 * @return {@code true} if the type is abstract or {@code null}, {@code false} otherwise
 	 * @throws JavaModelException
 	 *             the underlying JavaModelException thrown by the manipulated
 	 *             JDT APIs
 	 */
 	public static boolean isAbstractType(final IType type)
 			throws JavaModelException {
+		if(type == null) {
+			return true;
+		}
 		return Flags.isAbstract(type.getFlags());
 	}
 
@@ -780,6 +783,23 @@ public final class JdtUtils {
 		}
 		return findType;
 	}
+	
+	/**
+	 * @param compilationUnit the compilation unit to analyze
+	 * @param handleIdentifier the target type identifier
+	 * @return the found {@link IType} or {@code null} if none was found.
+	 * @throws JavaModelException
+	 */
+	public static IType resolveType(final ICompilationUnit compilationUnit, final String handleIdentifier) throws JavaModelException {
+		final IType[] allTypes = compilationUnit.getAllTypes();
+		for(IType type: allTypes) {
+			if(type.getHandleIdentifier().equals(handleIdentifier)) {
+				return type;
+			}
+		}
+		return null;
+	}
+
 
 	/**
 	 * Returns the hierarchy for the given type, or null if it could not be
@@ -1259,5 +1279,6 @@ public final class JdtUtils {
 	public static boolean isSetter(final IMethod javaMethod) throws JavaModelException {
 		return javaMethod != null && javaMethod.getElementName().startsWith("set") ;
 	}
+
 	
 }

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/AbstractJaxrsElementValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/AbstractJaxrsElementValidatorDelegate.java
@@ -63,33 +63,16 @@ public abstract class AbstractJaxrsElementValidatorDelegate<T extends JaxrsBaseE
 	 * @throws CoreException
 	 */
 	public void validate(final T element, final CompilationUnit ast) throws CoreException {
-		validate(element, ast, true);
-	}
-	
-	/**
-	 * Validates the given {@link IJaxrsElement}.
-	 * 
-	 * @param element
-	 *            the JAX-RS element to validate
-	 * @param removeMarkers
-	 *            boolean to indicate if JAX-RS Problem markers related to
-	 *            the given element should be removed prior to validation, or
-	 *            not (assuming they were already removed).
-	 * @throws CoreException
-	 */
-	public void validate(final T element, final CompilationUnit ast, final boolean removeMarkers) throws CoreException {
-		final int previousProblemLevel = element.getMarkerSeverity();
-		if(removeMarkers) {
-			removeMarkers(element);
+		// skip if the element was removed (during as-you-type for example)
+		if(!element.exists()) {
+			return;
 		}
-		element.resetProblemLevel();
 		internalValidate(element, ast);
-		final int currentProblemLevel = element.getMarkerSeverity();
-		if(currentProblemLevel != previousProblemLevel) {
-			Logger.debug("Informing metamodel that problem level changed from {} to {}", previousProblemLevel,
-					currentProblemLevel);
+		if(element.hasProblem()) {
+			Logger.debug("Informing metamodel that problem level changed to {}", element.getMarkerSeverity());
 			((JaxrsMetamodel)element.getMetamodel()).notifyElementProblemLevelChanged(element);
 		}
+		
 	}
 
 	abstract void internalValidate(final T element, final CompilationUnit ast) throws CoreException;

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidatorDelegate.java
@@ -12,7 +12,6 @@ package org.jboss.tools.ws.jaxrs.ui.internal.validation;
 
 import java.util.Collection;
 
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.JavaModelException;
@@ -52,8 +51,7 @@ public class JaxrsMetamodelValidatorDelegate {
 	 */
 	void validate(JaxrsMetamodel metamodel) throws CoreException {
 		Logger.debug("Validating element {}", metamodel);
-		final IProject project = metamodel.getProject();
-		JaxrsMetamodelValidator.removeMarkers(metamodel, project);
+		JaxrsMetamodelValidator.removeMarkers(metamodel);
 		metamodel.resetProblemLevel();
 		final Collection<JaxrsJavaApplication> javaApplications = metamodel.findJavaApplications();
 		final Collection<JaxrsWebxmlApplication> webxmlApplications = metamodel.findWebxmlApplications();

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsParameterAggregatorValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsParameterAggregatorValidatorDelegate.java
@@ -36,10 +36,10 @@ public class JaxrsParameterAggregatorValidatorDelegate extends AbstractJaxrsElem
 	void internalValidate(final JaxrsParameterAggregator parameterAggregator, final CompilationUnit ast) throws CoreException {
 		Logger.debug("Validating element {}", parameterAggregator);
 		for (JaxrsParameterAggregatorField parameterAggregatorField : parameterAggregator.getAllFields()) {
-			new JaxrsParameterAggregatorFieldValidatorDelegate(markerManager).validate(parameterAggregatorField, ast, false);
+			new JaxrsParameterAggregatorFieldValidatorDelegate(markerManager).validate(parameterAggregatorField, ast);
 		}
 		for (JaxrsParameterAggregatorProperty parameterAggregatorProperty : parameterAggregator.getAllProperties()) {
-			new JaxrsParameterAggregatorPropertyValidatorDelegate(markerManager).validate(parameterAggregatorProperty, ast, false);
+			new JaxrsParameterAggregatorPropertyValidatorDelegate(markerManager).validate(parameterAggregatorProperty, ast);
 		}
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourceValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsResourceValidatorDelegate.java
@@ -64,16 +64,14 @@ public class JaxrsResourceValidatorDelegate extends AbstractJaxrsElementValidato
 		validatePathAnnotationValue(resource, ast);
 		validateAtLeastOneProviderWithBinding(resource);
 		for (IJaxrsResourceMethod resourceMethod : resource.getAllMethods()) {
-			new JaxrsResourceMethodValidatorDelegate(markerManager).validate((JaxrsResourceMethod) resourceMethod, ast,
-					false);
+			new JaxrsResourceMethodValidatorDelegate(markerManager).validate((JaxrsResourceMethod) resourceMethod, ast);
 		}
 		for (IJaxrsResourceField resourceField : resource.getAllFields()) {
-			new JaxrsResourceFieldValidatorDelegate(markerManager).validate((JaxrsResourceField) resourceField, ast,
-					false);
+			new JaxrsResourceFieldValidatorDelegate(markerManager).validate((JaxrsResourceField) resourceField, ast);
 		}
 		for (IJaxrsResourceProperty resourceProperty : resource.getAllProperties()) {
 			new JaxrsResourcePropertyValidatorDelegate(markerManager).validate(
-					(JaxrsResourceProperty) resourceProperty, ast, false);
+					(JaxrsResourceProperty) resourceProperty, ast);
 		}
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/LogListener.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/LogListener.java
@@ -1,0 +1,24 @@
+package org.jboss.tools.ws.jaxrs.core.junitrules;
+
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.IStatus;
+
+public class LogListener implements ILogListener {
+	
+	private boolean errorOccurred = false; 
+	
+	private final String pluginId;
+	
+	public LogListener(final String pluginId) {
+		this.pluginId = pluginId;
+	}
+	public boolean isErrorOccurred() {
+		return errorOccurred;
+	}
+	@Override
+	public void logging(IStatus status, String plugin) {
+		if(status.getSeverity() == IStatus.ERROR && plugin.equals(pluginId)) {
+			errorOccurred = true;
+		}
+	}
+}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/ResourcesUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/ResourcesUtils.java
@@ -80,8 +80,18 @@ public class ResourcesUtils {
 		return modifiedElement;
 	}
 
-	public static void replaceAllOccurrencesOfCode(ICompilationUnit compilationUnit, String oldContent,
-			String newContent, boolean useWorkingCopy) throws JavaModelException {
+	public static void removeSourceRange(final ICompilationUnit compilationUnit, final ISourceRange rangeToRemove,
+			final boolean useWorkingCopy) throws JavaModelException {
+		final ICompilationUnit unit = useWorkingCopy ? JavaElementsUtils.createWorkingCopy(compilationUnit) : compilationUnit;
+		final IBuffer buffer = ((IOpenable) unit).getBuffer();
+		buffer.replace(rangeToRemove.getOffset(), rangeToRemove.getLength(), "");
+		// IJavaElement modifiedMethod =
+		// workingCopy.getElementAt(sourceRange.getOffset());
+		JavaElementsUtils.saveAndClose(unit);
+	}
+	
+	public static void replaceAllOccurrencesOfCode(final ICompilationUnit compilationUnit, final String oldContent,
+			final String newContent, final boolean useWorkingCopy) throws JavaModelException {
 	
 		ICompilationUnit unit = JavaElementsUtils.getCompilationUnit(compilationUnit, useWorkingCopy);
 		IBuffer buffer = ((IOpenable) unit).getBuffer();

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsApplicationValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsApplicationValidatorTestCase.java
@@ -420,7 +420,6 @@ public class JaxrsApplicationValidatorTestCase {
 				validatorManager, reporter);
 		// validation
 		assertThat(findJaxrsMarkers(javaApplication1).length, equalTo(0));
-		assertThat(findJaxrsMarkers(javaApplication2).length, equalTo(0));
 		assertThat(metamodelMonitor.getMetamodelProblemLevelChanges().contains(metamodel), is(true));
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/quickfix/JavaCompletionProposalUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/quickfix/JavaCompletionProposalUtils.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 import org.eclipse.jface.text.IDocument;
 import org.jboss.tools.common.quickfix.IQuickFix;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaElement;
-import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 
 /**
  * Utility class to execute the completion proposals during the tests.
@@ -45,7 +44,7 @@ public class JavaCompletionProposalUtils {
 		fBuffer.commit(null, true);
 		manager.disconnect(path, LocationKind.IFILE, null);
 		// now, update the element with the latest changes
-		element.update(element.getJavaElement(), JdtUtils.parse(element.getJavaElement().getCompilationUnit(), null));
+		//element.update(element.getJavaElement(), JdtUtils.parse(element.getJavaElement().getCompilationUnit(), null));
 	}
 
 	/**

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/quickfix/TargetAnnotationMarkerResolutionTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/quickfix/TargetAnnotationMarkerResolutionTestCase.java
@@ -166,6 +166,7 @@ public class TargetAnnotationMarkerResolutionTestCase {
 		final IJavaCompletionProposal completionProposal = new AddHttpMethodTargetValuesCompletionProposal(compilationUnit,
 				JaxrsMarkerResolutionGenerator.findEffectiveSourceRange(compilationUnit, new ProblemLocation(javaProblems[0])));
 		JavaCompletionProposalUtils.applyCompletionProposal(completionProposal, bazMethod);
+		metamodelMonitor.processEvent(compilationUnit, IJavaElementDelta.CHANGED);
 		
 		// verification 2: revalidate, there should be 0 JAX-RS/Java error
 		new JaxrsMetamodelValidator().validate(toSet(resource), project, validationHelper, context,
@@ -197,6 +198,7 @@ public class TargetAnnotationMarkerResolutionTestCase {
 		final IJavaCompletionProposal completionProposal = new AddHttpMethodTargetValuesCompletionProposal(compilationUnit,
 				JaxrsMarkerResolutionGenerator.findEffectiveSourceRange(compilationUnit, new ProblemLocation(javaProblems[0])));
 		JavaCompletionProposalUtils.applyCompletionProposal(completionProposal, bazMethod);
+		metamodelMonitor.processEvent(compilationUnit, IJavaElementDelta.CHANGED);
 		
 		// verification 2: revalidate, there should be 0 JAX-RS/Java error
 		new JaxrsMetamodelValidator().validate(toSet(resource), project, validationHelper, context,
@@ -319,6 +321,7 @@ public class TargetAnnotationMarkerResolutionTestCase {
 		final IJavaCompletionProposal completionProposal = new AddNameBindingTargetValuesCompletionProposal(compilationUnit,
 				JaxrsMarkerResolutionGenerator.findEffectiveSourceRange(compilationUnit, new ProblemLocation(javaProblems[0])));
 		JavaCompletionProposalUtils.applyCompletionProposal(completionProposal, nameBinding);
+		metamodelMonitor.processEvent(compilationUnit, IJavaElementDelta.CHANGED);
 		
 		// verification 2: revalidate, there should be 0 JAX-RS/Java error
 		new JaxrsMetamodelValidator().validate(toSet(resource), project, validationHelper, context,
@@ -350,6 +353,7 @@ public class TargetAnnotationMarkerResolutionTestCase {
 		final IJavaCompletionProposal completionProposal = new AddNameBindingTargetValuesCompletionProposal(compilationUnit, 
 				JaxrsMarkerResolutionGenerator.findEffectiveSourceRange(compilationUnit, new ProblemLocation(javaProblems[0])));
 		JavaCompletionProposalUtils.applyCompletionProposal(completionProposal, nameBinding);
+		metamodelMonitor.processEvent(compilationUnit, IJavaElementDelta.CHANGED);
 		
 		// verification 2: revalidate, there should be 0 JAX-RS/Java error
 		new JaxrsMetamodelValidator().validate(toSet(resource), project, validationHelper, context,


### PR DESCRIPTION
Fixed problem that still remained when underlying resource was saved:
- the validator for the inner provider would run first and report a problem,
- then the top level resource validator would remove all markers for the underlying file and perform
  its validation, meaning that the markers for the inner provider would be gone.

Fixed a related problem where only top-level types would be considered, which excluded the inner provider.
