### PR TITLE
JBIDE-17457 - JAX-RS Resource Wizard has inconsistent validation of targ...

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsResourceCreationWizardPage.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsResourceCreationWizardPage.java
@@ -718,10 +718,7 @@ public class JaxrsResourceCreationWizardPage extends NewClassWizardPage {
 			this.targetClassText.setText(targetClass);
 		}
 		try {
-			if (this.targetClass == null) {
-				this.targetClassStatus = new Status(IStatus.WARNING, JBossJaxrsUIPlugin.PLUGIN_ID,
-						JaxrsResourceCreationMessages.JaxrsResourceCreationWizardPage_EmptyTargetClass);
-			} else if (getJavaProject() != null && getJavaProject().findType(this.targetClass) == null) {
+			if (this.targetClass != null && !this.targetClass.isEmpty() && getJavaProject() != null && getJavaProject().findType(this.targetClass) == null) {
 				this.targetClassStatus = new Status(IStatus.ERROR, JBossJaxrsUIPlugin.PLUGIN_ID,
 						JaxrsResourceCreationMessages.JaxrsResourceCreationWizardPage_InvalidTargetClass);
 			} else {


### PR DESCRIPTION
...et entity

The wizard now allows for null/empty values of the Target Entity, even if a previous
value was entered by the user.
