### PR TITLE
JBIDE-17296 - Warning decorator on the 'JAX-RS Web Services' node when no application is defined

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -906,6 +906,13 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	}
 	
 	/**
+	 * @return {@code true} if the metamodel has custom {@link IJaxrsElement}s (ie any element, except the 6 built-in {@link JaxrsBuiltinHttpMethod}), {@code  false} otherwise.
+	 */
+	public boolean hasCustomElements() {
+		return this.elements.size() > 6;
+	}
+
+	/**
 	 * Returns the {@link IJaxrsElement} for the given identifier.
 	 * 
 	 * @param identifier the element identifier
@@ -938,14 +945,14 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	}
 
 	/**
-	 * Returns the {@link EnumElementKind} for the given {@link IFile} if it
+	 * Returns the {@link EnumElementKind} for the given {@link IResource} if it
 	 * matches a known "shadow" element (ie, that was maybe removed or validated
 	 * during a previous operation), {@code null} otherwise.
 	 * 
 	 * @param changedResource
 	 * @return
 	 */
-	public EnumElementKind getShadowElementKind(final IFile changedResource) {
+	public Set<EnumElementKind> getShadowElementKinds(final IResource changedResource) {
 		return shadowElementsCache.lookup(changedResource);
 	}
 	

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsShadowElementsCache.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsShadowElementsCache.java
@@ -12,8 +12,10 @@
 package org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jdt.core.IJavaElement;
@@ -38,7 +40,7 @@ public class JaxrsShadowElementsCache {
 	 * {@link IJaxrsElement} are indexed by their underlying resource *portable
 	 * path*. The indexed value is the {@link EnumElementKind} of the element.
 	 */
-	private Map<String, EnumElementKind> elements = new HashMap<String, EnumElementKind>();
+	private Map<String, Set<EnumElementKind>> elements = new HashMap<String, Set<EnumElementKind>>();
 
 	/**
 	 * Constructor
@@ -58,7 +60,11 @@ public class JaxrsShadowElementsCache {
 		final List<IJaxrsElement> allElements = metamodel.getAllElements();
 		for (IJaxrsElement element : allElements) {
 			if (isRelevantForIndexation(element)) {
-				elements.put(element.getResource().getLocation().toPortableString(), element.getElementKind());
+				final String key = element.getResource().getLocation().toPortableString();
+				if(!elements.containsKey(key)) {
+					elements.put(key, new HashSet<EnumElementKind>());
+				}
+				elements.get(key).add(element.getElementKind());
 			}
 		}
 	}
@@ -99,7 +105,11 @@ public class JaxrsShadowElementsCache {
 		if (element == null || element.getResource() == null) {
 			return;
 		}
-		elements.put(element.getResource().getLocation().toPortableString(), element.getElementKind());
+		final String key = element.getResource().getLocation().toPortableString();
+		if(!elements.containsKey(key)) {
+			elements.put(key, new HashSet<EnumElementKind>());
+		}
+		elements.get(key).add(element.getElementKind());
 	}
 
 	/**
@@ -109,7 +119,7 @@ public class JaxrsShadowElementsCache {
 	 * @param resource
 	 *            the resource whose data should be retrieved.
 	 */
-	public EnumElementKind lookup(final IResource resource) {
+	public Set<EnumElementKind> lookup(final IResource resource) {
 		if (resource == null) {
 			return null;
 		}

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidatorDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsMetamodelValidatorDelegate.java
@@ -49,13 +49,13 @@ public class JaxrsMetamodelValidatorDelegate {
 	 * @param metamodel the metamodel to validate
 	 * @throws CoreException
 	 */
-	void validate(JaxrsMetamodel metamodel) throws CoreException {
+	void validate(final JaxrsMetamodel metamodel) throws CoreException {
 		Logger.debug("Validating element {}", metamodel);
 		JaxrsMetamodelValidator.removeJaxrsMarkers(metamodel.getProject());
 		metamodel.resetProblemLevel();
 		final Collection<JaxrsJavaApplication> javaApplications = metamodel.findJavaApplications();
 		final Collection<JaxrsWebxmlApplication> webxmlApplications = metamodel.findWebxmlApplications();
-		if (javaApplications.isEmpty() && webxmlApplications.isEmpty()) {
+		if (javaApplications.isEmpty() && webxmlApplications.isEmpty() && metamodel.hasCustomElements()) {
 			markerManager.addMarker(metamodel,
 					JaxrsValidationMessages.APPLICATION_NO_OCCURRENCE_FOUND, new String[0], JaxrsPreferences.APPLICATION_NO_OCCURRENCE_FOUND);
 		} else if (javaApplications.size() >= 2 || (javaApplications.size() >= 1 && webxmlApplications.size() >= 1)) {

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs11ResourceValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs11ResourceValidatorTestCase.java
@@ -106,7 +106,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 	@Test
 	public void shouldValidateCustomerResourceMethod() throws CoreException, ValidationException {
 		// preconditions
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		final JaxrsResource customerResource = (JaxrsResource) metamodel
 				.findElement("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource", EnumElementCategory.RESOURCE);
 		deleteJaxrsMarkers(customerResource);
@@ -174,7 +175,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 		// pre-conditions
 		ICompilationUnit compilationUnit = metamodelMonitor.createCompilationUnit("ValidationResource.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "ValidationResource.java");
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.ValidationResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.ValidationResource");
 		final JaxrsResource resource = (JaxrsResource) metamodel.findElement(compilationUnit.findPrimaryType());
 		deleteJaxrsMarkers(resource);
 		metamodelMonitor.resetElementChangesNotifications();
@@ -224,7 +226,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 		// pre-conditions
 		ICompilationUnit compilationUnit = metamodelMonitor.createCompilationUnit("IValidationResource.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "IValidationResource.java");
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.IValidationResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.IValidationResource");
 		final JaxrsResource resource = (JaxrsResource) metamodel.findElement(compilationUnit.findPrimaryType());
 		deleteJaxrsMarkers(resource);
 		metamodelMonitor.resetElementChangesNotifications();
@@ -441,7 +444,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 	public void shouldValidateCustomerResourceMethodWithDotCharacterInPathParam() throws CoreException,
 			ValidationException {
 		// preconditions
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		final IType customerJavaType = metamodelMonitor
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i.d}\")", false);
@@ -506,7 +510,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i-d}\")", false);
 		replaceAllOccurrencesOfCode(customerJavaType, "@PathParam(\"id\")", "@PathParam(\"i-d\")", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		final JaxrsBaseElement customerResource = (JaxrsBaseElement) metamodel
 				.findElement(customerJavaType);
 		deleteJaxrsMarkers(customerResource);
@@ -562,7 +567,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 	public void shouldValidateCustomerResourceMethodWithUnderscoreCharacterInPathParam() throws CoreException,
 			ValidationException {
 		// preconditions
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		final IType customerJavaType = metamodelMonitor
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i_d}\")", false);
@@ -655,7 +661,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 	public void shouldReportProblemOnCustomerResourceMethodWithSingleCharacterInPathParam() throws CoreException,
 			ValidationException {
 		// preconditions
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		final IType customerJavaType = metamodelMonitor
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CustomerResource");
 		replaceAllOccurrencesOfCode(customerJavaType, "@Path(\"{id}\")", "@Path(\"{i}\")", false);
@@ -689,6 +696,7 @@ public class Jaxrs11ResourceValidatorTestCase {
 		final ICompilationUnit compilationUnit = metamodelMonitor.createCompilationUnit("CarResource.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "CarResource.java");
 		final JaxrsResource carResource = metamodelMonitor.createResource(compilationUnit.findPrimaryType());
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication");
 		metamodelMonitor.resetElementChangesNotifications();
 		validate(carResource);
 		// validation
@@ -996,7 +1004,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 		final ICompilationUnit boatResourceCompilationUnit = metamodelMonitor.createCompilationUnit("BoatResource.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "BoatResource.java");
 		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@Path(\"{id}\")", "@Path(\"{type}/{id}\")", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
 		final JaxrsResource boatResource = metamodel.findResource(boatResourceCompilationUnit.findPrimaryType());
 		metamodelMonitor.resetElementChangesNotifications();
 		
@@ -1187,7 +1196,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@PathParam(\"type\") //field", "//@PathParam(\"type\")", false);
 		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "//@PathParam(\"type\") //property", "@PathParam(\"type\")", false);
 		ResourcesUtils.replaceAllOccurrencesOfCode(boatResourceCompilationUnit, "@Path(\"{id}\")", "@Path(\"{type}/{id}\")", false);
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.BoatResource");
 		final JaxrsResource boatResource = metamodel.findResource(boatResourceCompilationUnit.findPrimaryType());
 		metamodelMonitor.resetElementChangesNotifications();
 		
@@ -1301,7 +1311,8 @@ public class Jaxrs11ResourceValidatorTestCase {
 	public void shouldNotReportProblemOnMethodParamOfTypeEnumeration() throws CoreException, ValidationException {
 		final ICompilationUnit boatResourceCompilationUnit = metamodelMonitor.createCompilationUnit("ResourceWithEnumMethodParams.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "HelloWorld.java");
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.HelloWorld");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.HelloWorld");
 		final JaxrsResource resource = metamodel.findResource(boatResourceCompilationUnit.findPrimaryType());
 		metamodelMonitor.resetElementChangesNotifications();
 		

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ParamConverterProviderTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ParamConverterProviderTestCase.java
@@ -128,7 +128,10 @@ public class Jaxrs20ParamConverterProviderTestCase {
 		metamodelMonitor.createCompilationUnit("Truck.txt", "org.jboss.tools.ws.jaxrs.sample.services", "Truck.java");
 		final ICompilationUnit compilationUnit = metamodelMonitor.createCompilationUnit("TruckResource.txt",
 				"org.jboss.tools.ws.jaxrs.sample.services", "TruckResource.java");
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.Truck", "org.jboss.tools.ws.jaxrs.sample.services.TruckResource", "org.jboss.tools.ws.jaxrs.sample.services.CarParamConverterProvider");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.Truck",
+				"org.jboss.tools.ws.jaxrs.sample.services.TruckResource",
+				"org.jboss.tools.ws.jaxrs.sample.services.CarParamConverterProvider");
 		final JaxrsResource truckResource = metamodelMonitor.createResource(compilationUnit.findPrimaryType());
 		metamodelMonitor.resetElementChangesNotifications();
 

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsNameBindingValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/JaxrsNameBindingValidatorTestCase.java
@@ -105,7 +105,8 @@ public class JaxrsNameBindingValidatorTestCase {
 	public void shouldValidateNameBinding() throws CoreException, ValidationException {
 		// preconditions
 		// delete CarResource that has param validation errors
-		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding");
+		metamodelMonitor.createElements("org.jboss.tools.ws.jaxrs.sample.services.RestApplication",
+				"org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding");
 		final IType customNameBindingType = metamodelMonitor
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.interceptors.CustomInterceptorBinding");
 		final JaxrsBaseElement customNameBinding = (JaxrsBaseElement) metamodel


### PR DESCRIPTION
No warning appears if there is no JAX-RS application _AND_ no other JAX-RS element in the project, since having a JAX-RS application without any JAX-RS resource is useless.
