### PR TITLE
JBIDE-16163 - Missing update in JAX-RS explorer when facing to quick change in code

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilter.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilter.java
@@ -50,6 +50,7 @@ import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 
 public class JavaElementDeltaFilter {
 
+	public final static int ANY_EVENT = POST_RECONCILE + POST_CHANGE;
 	private final static int WORKING_COPY = 0x1;
 	private final static int PRIMARY_COPY = 0x2;
 
@@ -77,30 +78,30 @@ public class JavaElementDeltaFilter {
 				.after(POST_RECONCILE).in(WORKING_COPY);
 		accept().when(COMPILATION_UNIT).is(REMOVED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
 
-		accept().when(TYPE).is(ADDED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(TYPE).is(ADDED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
 		// Supertypes changes. Renaming a type ends up with
 		// remove+add operations
-		accept().when(TYPE).is(CHANGED).withFlags(F_SUPER_TYPES).after(POST_RECONCILE).in(WORKING_COPY);
-		accept().when(TYPE).is(CHANGED).withFlags(F_MARKER_ADDED).after(POST_RECONCILE).in(WORKING_COPY);
-		accept().when(TYPE).is(REMOVED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(TYPE).is(CHANGED).withFlags(F_SUPER_TYPES).after(ANY_EVENT).in(WORKING_COPY);
+		accept().when(TYPE).is(CHANGED).withFlags(F_MARKER_ADDED).after(ANY_EVENT).in(WORKING_COPY);
+		accept().when(TYPE).is(REMOVED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
 
-		accept().when(METHOD).is(ADDED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(METHOD).is(CHANGED).withFlags(F_SIGNATURE).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(METHOD).is(CHANGED).withFlags(F_MARKER_ADDED).after(POST_RECONCILE)
+		accept().when(METHOD).is(ADDED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(METHOD).is(CHANGED).withFlags(F_SIGNATURE).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(METHOD).is(CHANGED).withFlags(F_MARKER_ADDED).after(ANY_EVENT)
 				.in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(METHOD).is(CHANGED).withFlags(F_MARKER_REMOVED).after(POST_RECONCILE)
+		accept().when(METHOD).is(CHANGED).withFlags(F_MARKER_REMOVED).after(ANY_EVENT)
 				.in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(METHOD).is(REMOVED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(METHOD).is(REMOVED).withFlags(F_CONTENT).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(METHOD).is(REMOVED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(METHOD).is(REMOVED).withFlags(F_CONTENT).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
 
-		accept().when(FIELD).is(ADDED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(FIELD).is(CHANGED).withFlags(F_CONTENT).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(FIELD).is(REMOVED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(FIELD).is(ADDED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(FIELD).is(CHANGED).withFlags(F_CONTENT).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(FIELD).is(REMOVED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
 
-		accept().when(ANNOTATION).is(ADDED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(ANNOTATION).is(CHANGED).withFlags(F_CONTENT).after(POST_RECONCILE)
+		accept().when(ANNOTATION).is(ADDED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(ANNOTATION).is(CHANGED).withFlags(F_CONTENT).after(ANY_EVENT)
 				.in(PRIMARY_COPY + WORKING_COPY);
-		accept().when(ANNOTATION).is(REMOVED).after(POST_RECONCILE).in(PRIMARY_COPY + WORKING_COPY);
+		accept().when(ANNOTATION).is(REMOVED).after(ANY_EVENT).in(PRIMARY_COPY + WORKING_COPY);
 
 	}
 
@@ -235,7 +236,7 @@ public class JavaElementDeltaFilter {
 
 		public boolean match(Rule matcher) {
 			return this.elementKind == matcher.elementKind && this.deltaKind == matcher.deltaKind
-					&& this.eventType == matcher.eventType && ((this.unitContext & matcher.unitContext) != 0)
+					&& ((this.eventType & matcher.eventType) > 0) && ((this.unitContext & matcher.unitContext) != 0)
 					&& (this.flags.equals(matcher.flags));
 		}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/cnf/UriPathTemplateCategory.java
@@ -175,8 +175,10 @@ public class UriPathTemplateCategory implements ITreeContentProvider {
 	 */
 	public void refreshContent() {
 		try {
-			final IJaxrsMetamodel metamodel= JaxrsMetamodelLocator.get(javaProject);
-			parent.refreshContent(metamodel);
+			final IJaxrsMetamodel metamodel= JaxrsMetamodelLocator.get(javaProject, true);
+			if(metamodel != null) {
+				parent.refreshContent(metamodel);
+			}
 		} catch (CoreException e) {
 			Logger.error("Failed to determine the problem severity for the JAX-RS Web Services", e);
 		}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElement20ChangedProcessingTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElement20ChangedProcessingTestCase.java
@@ -12,18 +12,15 @@ import static org.junit.Assert.assertThat;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsElementFactory;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsProvider;
-import org.jboss.tools.ws.jaxrs.core.jdt.Flags;
 import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JavaElementsUtils;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
@@ -39,7 +36,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class JavaElement20ChangedProcessingTestCase {
-	private final static int ANY_EVENT_TYPE = 0;
 	private static final boolean PRIMARY_COPY = false;
 	@ClassRule
 	public static WorkspaceSetupRule workspaceSetupRule = new WorkspaceSetupRule(
@@ -55,18 +51,6 @@ public class JavaElement20ChangedProcessingTestCase {
 		assertThat(metamodel, notNullValue());
 	}
 
-	private void processEvent(final IJavaElement element, final int deltaKind) throws CoreException {
-		final JavaElementChangedEvent delta = new JavaElementChangedEvent(element, deltaKind, ANY_EVENT_TYPE, JdtUtils.parse(element,
-				new NullProgressMonitor()), Flags.NONE);
-		metamodel.processJavaElementChange(delta, new NullProgressMonitor());
-	}
-
-	private void processEvent(final ICompilationUnit element, final int deltaKind) throws CoreException {
-		final JavaElementChangedEvent delta = new JavaElementChangedEvent(element, deltaKind, ANY_EVENT_TYPE, JdtUtils.parse(element,
-				new NullProgressMonitor()), Flags.NONE);
-		metamodel.processJavaElementChange(delta, new NullProgressMonitor());
-	}
-	
 	private List<IJaxrsElement> createElement(final IType type) throws CoreException, JavaModelException {
 		return JaxrsElementFactory.createElements(type, JdtUtils.parse(type, null), metamodel, null);
 	}
@@ -81,7 +65,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider",
 				"public class CustomJAXRS2Provider implements ContainerRequestFilter", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(provider, notNullValue());
@@ -100,7 +84,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomRequestFilter implements ContainerRequestFilter",
 				"CustomRequestFilter", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), nullValue());
 	}
@@ -116,7 +100,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomRequestFilter implements ContainerRequestFilter",
 				"CustomRequestFilter", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), equalTo(provider));
 		assertThat(provider.getElementKind(), equalTo(EnumElementKind.UNDEFINED_PROVIDER));
@@ -131,7 +115,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider",
 				"public class CustomJAXRS2Provider implements ContainerResponseFilter", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(provider, notNullValue());
@@ -150,7 +134,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomResponseFilter implements ContainerResponseFilter",
 				"CustomResponseFilter", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), nullValue());
 		
@@ -167,7 +151,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomResponseFilter implements ContainerResponseFilter",
 				"CustomResponseFilter", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), equalTo(provider));
 		assertThat(provider.getElementKind(), equalTo(EnumElementKind.UNDEFINED_PROVIDER));
@@ -182,11 +166,11 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider",
 				"public class CustomJAXRS2Provider implements ContainerResponseFilter", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		replaceAllOccurrencesOfCode(compilationUnit,
 				"public class CustomJAXRS2Provider implements ContainerResponseFilter",
 				"public class CustomJAXRS2Provider implements ContainerRequestFilter, ContainerResponseFilter", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(provider, notNullValue());
@@ -206,7 +190,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(compilationUnit,
 				"CustomJAXRS2ContainerFilter implements ContainerRequestFilter, ContainerResponseFilter",
 				"CustomJAXRS2ContainerFilter implements ContainerResponseFilter", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider modifiedProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(modifiedProvider, notNullValue());
@@ -226,7 +210,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(compilationUnit,
 				"CustomJAXRS2ContainerFilter implements ContainerRequestFilter, ContainerResponseFilter",
 				"CustomJAXRS2ContainerFilter implements ContainerRequestFilter", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider modifiedProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(modifiedProvider, notNullValue());
@@ -242,7 +226,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider",
 				"public class CustomJAXRS2Provider implements ReaderInterceptor", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(provider, notNullValue());
@@ -260,7 +244,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomReaderInterceptor implements ReaderInterceptor",
 				"CustomReaderInterceptor", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), nullValue());
 		assertThat(provider.getElementKind(), equalTo(EnumElementKind.UNDEFINED_PROVIDER));
@@ -277,7 +261,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomReaderInterceptor implements ReaderInterceptor",
 				"CustomReaderInterceptor", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), equalTo(provider));
 		assertThat(provider.getElementKind(), equalTo(EnumElementKind.UNDEFINED_PROVIDER));
@@ -292,7 +276,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider",
 				"public class CustomJAXRS2Provider implements WriterInterceptor", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(provider, notNullValue());
@@ -310,7 +294,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomWriterInterceptor implements WriterInterceptor",
 				"CustomWriterInterceptor", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), nullValue());
 	}
@@ -326,7 +310,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(providerType, "CustomWriterInterceptor implements WriterInterceptor",
 				"CustomWriterInterceptor", false);
-		processEvent(providerType, CHANGED);
+		metamodelMonitor.processEvent(providerType, CHANGED);
 		// verification
 		assertThat(metamodel.findProvider(providerType), equalTo(provider));
 		assertThat(provider.getElementKind(), equalTo(EnumElementKind.UNDEFINED_PROVIDER));
@@ -341,10 +325,10 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider",
 				"public class CustomJAXRS2Provider implements ReaderInterceptor", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		replaceAllOccurrencesOfCode(compilationUnit, "public class CustomJAXRS2Provider implements ReaderInterceptor",
 				"public class CustomJAXRS2Provider implements ReaderInterceptor, WriterInterceptor", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(provider, notNullValue());
@@ -364,7 +348,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(compilationUnit,
 				"CustomJAXRS2EntityInterceptor implements ReaderInterceptor, WriterInterceptor",
 				"CustomJAXRS2EntityInterceptor implements ReaderInterceptor", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider modifiedProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(modifiedProvider, notNullValue());
@@ -384,7 +368,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(compilationUnit,
 				"CustomJAXRS2EntityInterceptor implements ReaderInterceptor, WriterInterceptor",
 				"CustomJAXRS2EntityInterceptor implements WriterInterceptor", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsProvider modifiedProvider = metamodel.findProvider(compilationUnit.findPrimaryType());
 		assertThat(modifiedProvider, notNullValue());
@@ -400,7 +384,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation
 		replaceAllOccurrencesOfCode(compilationUnit, "public @interface CustomJAXRS2NameBinding",
 				"@NameBinding public @interface CustomJAXRS2NameBinding", false);
-		processEvent(compilationUnit, CHANGED);
+		metamodelMonitor.processEvent(compilationUnit, CHANGED);
 		// verification
 		final IJaxrsNameBinding nameBinding = metamodel.findNameBinding(compilationUnit.findPrimaryType().getFullyQualifiedName());
 		assertThat(nameBinding, notNullValue());
@@ -414,7 +398,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		assertThat(nameBindingType, notNullValue());
 		// operation
 		replaceAllOccurrencesOfCode(nameBindingType, "@NameBinding", "", false);
-		processEvent(nameBindingType, CHANGED);
+		metamodelMonitor.processEvent(nameBindingType, CHANGED);
 		// verification
 		final IJaxrsNameBinding nameBinding = metamodel.findNameBinding(nameBindingType.getFullyQualifiedName());
 		assertThat(nameBinding, nullValue());
@@ -446,7 +430,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation: add the @NameBinding annotation
 		replaceAllOccurrencesOfCode(nameBindingCompilationUnit, "public @interface CustomJAXRS2NameBinding",
 				"@NameBinding @interface class CustomJAXRS2NameBinding", false);
-		processEvent(nameBindingCompilationUnit, CHANGED);
+		metamodelMonitor.processEvent(nameBindingCompilationUnit, CHANGED);
 		// verification: NameBinding exist in metamodel and on the 2 providers
 		final IJaxrsNameBinding nameBinding = metamodel.findNameBinding(nameBindingCompilationUnit.findPrimaryType().getFullyQualifiedName());
 		assertThat(nameBinding, notNullValue());
@@ -468,7 +452,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		assertThat(customResponseFilterWithBinding.getNameBindingAnnotations().size(), equalTo(1));
 		// operation: remove the @NameBinding annotation
 		replaceAllOccurrencesOfCode(nameBindingType, "@NameBinding", "", false);
-		processEvent(nameBindingType, CHANGED);
+		metamodelMonitor.processEvent(nameBindingType, CHANGED);
 		// verification
 		final IJaxrsProvider provider = metamodel.findProvider(nameBindingType);
 		assertThat(provider, nullValue());
@@ -485,7 +469,7 @@ public class JavaElement20ChangedProcessingTestCase {
 				"@PathParam(\"id1\") private String id1;", false);
 		assertThat(parameterAggregatorType, notNullValue());
 		// operation
-		processEvent(parameterAggregatorType, ADDED);
+		metamodelMonitor.processEvent(parameterAggregatorType, ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(aggregator, notNullValue());
@@ -502,7 +486,7 @@ public class JavaElement20ChangedProcessingTestCase {
 				"@PathParam(\"id2\") public void setId2(String id2) {}", false);
 		assertThat(parameterAggregatorType, notNullValue());
 		// operation
-		processEvent(parameterAggregatorType, ADDED);
+		metamodelMonitor.processEvent(parameterAggregatorType, ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(aggregator, notNullValue());
@@ -514,7 +498,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IType carType = metamodelMonitor.resolveType("org.jboss.tools.ws.jaxrs.sample.services.CarResource");
 		assertThat(carType, notNullValue());
 		// operation
-		processEvent(carType, ADDED);
+		metamodelMonitor.processEvent(carType, ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(carType.getFullyQualifiedName());
 		assertThat(aggregator, nullValue());
@@ -529,7 +513,7 @@ public class JavaElement20ChangedProcessingTestCase {
 				.resolveType("org.jboss.tools.ws.jaxrs.sample.services.ParameterAggregator");
 		assertThat(parameterAggregatorType, notNullValue());
 		// operation: type added
-		processEvent(parameterAggregatorType, ADDED);
+		metamodelMonitor.processEvent(parameterAggregatorType, ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(aggregator, nullValue());
@@ -550,7 +534,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "private String id1;",
 				"@PathParam(\"id1\") private String id1;", false);
 		final IField field = JavaElementsUtils.getField(parameterAggregatorType, "id1");
-		processEvent(field.getAnnotations()[0], ADDED);
+		metamodelMonitor.processEvent(field.getAnnotations()[0], ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(aggregator, notNullValue());
@@ -571,7 +555,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "// PLACEHOLDER",
 				"@PathParam(\"id1\") private String id1;", false);
 		final IField field = JavaElementsUtils.getField(parameterAggregatorType, "id1");
-		processEvent(field, ADDED);
+		metamodelMonitor.processEvent(field, ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType
 				.getFullyQualifiedName());
@@ -595,7 +579,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "public void setId2(String id2)",
 				"@PathParam(\"id2\") public void setId2(String id2)", false);
 		final IMethod method = JavaElementsUtils.getMethod(parameterAggregatorType, "setId2");
-		processEvent(method.getAnnotations()[0], ADDED);
+		metamodelMonitor.processEvent(method.getAnnotations()[0], ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(aggregator, notNullValue());
@@ -616,7 +600,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "// PLACEHOLDER",
 				"@PathParam(\"id2\") public void setId2(String id2) {}", false);
 		final IMethod method = JavaElementsUtils.getMethod(parameterAggregatorType, "setId2");
-		processEvent(method, ADDED);
+		metamodelMonitor.processEvent(method, ADDED);
 		// verification
 		final IJaxrsParameterAggregator aggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(aggregator, notNullValue());
@@ -640,7 +624,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType,
 				"private String id2;", "@PathParam(\"id2\") private String id2;", false);
 		final IField field = JavaElementsUtils.getField(parameterAggregatorType, "id2");
-		processEvent(field.getAnnotations()[0], ADDED);
+		metamodelMonitor.processEvent(field.getAnnotations()[0], ADDED);
 		// verification
 		assertThat(aggregator, notNullValue());
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
@@ -664,7 +648,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id1\") private String id1;",
 				"@PathParam(\"id1\") private String id1; \n @PathParam(\"id2\") private String id2;", false);
 		final IField field = JavaElementsUtils.getField(parameterAggregatorType, "id2");
-		processEvent(field, ADDED);
+		metamodelMonitor.processEvent(field, ADDED);
 		// verification
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
 		assertThat(aggregator.getAllFields().size(), equalTo(2));
@@ -688,7 +672,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "public void setId3(String id3)",
 				"@PathParam(\"id3\") public void setId3(String id3)", false);
 		final IMethod method = JavaElementsUtils.getMethod(parameterAggregatorType, "setId3");
-		processEvent(method.getAnnotations()[0], ADDED);
+		metamodelMonitor.processEvent(method.getAnnotations()[0], ADDED);
 		// verification
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
 		assertThat(aggregator.getAllProperties().size(), equalTo(2));
@@ -711,7 +695,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "// PLACEHOLDER",
 				"// PLACEHOLDER \n @PathParam(\"id3\") public void setId3(String id3) {}", false);
 		final IMethod method = JavaElementsUtils.getMethod(parameterAggregatorType, "setId3");
-		processEvent(method, ADDED);
+		metamodelMonitor.processEvent(method, ADDED);
 		// verification
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
 		assertThat(aggregator.getAllProperties().size(), equalTo(2));
@@ -735,7 +719,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IAnnotation annotation = JavaElementsUtils.getField(parameterAggregatorType, "id2").getAnnotations()[0];
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id2\") private String id2;",
 				"private String id2;", false);
-		processEvent(annotation, REMOVED);
+		metamodelMonitor.processEvent(annotation, REMOVED);
 		// verification
 		assertThat(aggregator, notNullValue());
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
@@ -760,7 +744,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IField field = JavaElementsUtils.getField(parameterAggregatorType, "id2");
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id2\") private String id2;",
 				"", false);
-		processEvent(field, REMOVED);
+		metamodelMonitor.processEvent(field, REMOVED);
 		// verification
 		assertThat(aggregator, notNullValue());
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
@@ -786,7 +770,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IAnnotation annotation = JavaElementsUtils.getMethod(parameterAggregatorType, "setId3").getAnnotations()[0];
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id3\") public void setId3(String id3) {}",
 				"public void setId3(String id3) {}", false);
-		processEvent(annotation, REMOVED);
+		metamodelMonitor.processEvent(annotation, REMOVED);
 		// verification
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
 		assertThat(aggregator.getAllProperties().size(), equalTo(1));
@@ -811,7 +795,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IMethod method = JavaElementsUtils.getMethod(parameterAggregatorType, "setId3");
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id3\") public void setId3(String id3) {}",
 				"", false);
-		processEvent(method, REMOVED);
+		metamodelMonitor.processEvent(method, REMOVED);
 		// verification
 		assertThat(aggregator.getElementKind(), equalTo(EnumElementKind.PARAMETER_AGGREGATOR));
 		assertThat(aggregator.getAllProperties().size(), equalTo(1));
@@ -835,7 +819,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IAnnotation annotation = JavaElementsUtils.getField(parameterAggregatorType, "id2").getAnnotations()[0];
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id2\") private String id2;",
 				"private String id2;", false);
-		processEvent(annotation, REMOVED);
+		metamodelMonitor.processEvent(annotation, REMOVED);
 		// verification: parameter aggregator still exists, but it is empty
 		final IJaxrsParameterAggregator remainingParameterAggregator = metamodel
 				.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
@@ -861,7 +845,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		// operation: annotated field removed
 		final IField field = JavaElementsUtils.getField(parameterAggregatorType, "id2");
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id2\") private String id2;", "", false);
-		processEvent(field, REMOVED);
+		metamodelMonitor.processEvent(field, REMOVED);
 		// verification: parameter aggregator still exists, but it is empty
 		final IJaxrsParameterAggregator remainingParameterAggregator = metamodel
 				.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
@@ -893,7 +877,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IAnnotation annotation = JavaElementsUtils.getMethod(parameterAggregatorType, "setId2").getAnnotations()[0];
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id2\") public void setId2(String id2) {}",
 				"public void setId2(String id2) {}", false);
-		processEvent(annotation, REMOVED);
+		metamodelMonitor.processEvent(annotation, REMOVED);
 		// verification: parameter aggregator still exists, but it is empty
 		final IJaxrsParameterAggregator remainingParameterAggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(remainingParameterAggregator, notNullValue());
@@ -924,7 +908,7 @@ public class JavaElement20ChangedProcessingTestCase {
 		final IMethod method = JavaElementsUtils.getMethod(parameterAggregatorType, "setId2");
 		replaceAllOccurrencesOfCode(parameterAggregatorType, "@PathParam(\"id2\") public void setId2(String id2) {}",
 				"", false);
-		processEvent(method, REMOVED);
+		metamodelMonitor.processEvent(method, REMOVED);
 		// verification: parameter aggregator still exists, but it is empty
 		final IJaxrsParameterAggregator remainingParameterAggregator = metamodel.findParameterAggregator(parameterAggregatorType.getFullyQualifiedName());
 		assertThat(remainingParameterAggregator, notNullValue());

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilterTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilterTestCase.java
@@ -73,17 +73,10 @@ public class JavaElementDeltaFilterTestCase {
 	}
 	
 	@Test
-	public void shouldAcceptPostChangeEventOnly() throws JavaModelException {
+	public void shouldAcceptPostChangeAndPostReconcileEvents() throws JavaModelException {
 		final IJavaElement element = createMock(IType.class, TYPE, workingCopy);
-		assertFalse("Wrong result", filter.apply(createEvent(element, ADDED, POST_CHANGE, Flags.NONE)));
+		assertTrue("Wrong result", filter.apply(createEvent(element, ADDED, POST_CHANGE, Flags.NONE)));
 		assertTrue("Wrong result", filter.apply(createEvent(element, ADDED, POST_RECONCILE, Flags.NONE)));
-	}
-
-	@Test
-	public void shouldAcceptPostReconcileEventOnly() throws JavaModelException {
-		final IJavaElement element = createMock(IType.class, ANNOTATION, workingCopy);
-		assertTrue("Wrong result", filter.apply(createEvent(element, ADDED, POST_RECONCILE, Flags.NONE)));
-		assertFalse("Wrong result", filter.apply(createEvent(element, ADDED, POST_CHANGE, Flags.NONE)));
 	}
 
 	@Test

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsMetamodelBuilderTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsMetamodelBuilderTestCase.java
@@ -33,7 +33,7 @@ import org.jboss.tools.ws.jaxrs.core.JBossJaxrsCorePlugin;
 import org.jboss.tools.ws.jaxrs.core.configuration.ProjectNatureUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelLocator;
@@ -56,7 +56,7 @@ public class JaxrsMetamodelBuilderTestCase {
 	public JaxrsMetamodelMonitor metamodelMonitor = new JaxrsMetamodelMonitor("org.jboss.tools.ws.jaxrs.tests.sampleproject", true);
 	
 	@Rule
-	public TestWatcher watcher = new TestWatcher();
+	public TestBanner watcher = new TestBanner();
 	
 	private JaxrsMetamodel metamodel = null;
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsMetamodelChangedProcessorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JaxrsMetamodelChangedProcessorTestCase.java
@@ -46,7 +46,7 @@ import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.jdt.Flags;
 import org.jboss.tools.ws.jaxrs.core.jdt.JdtUtils;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsEndpoint;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsHttpMethod;
@@ -67,7 +67,7 @@ public class JaxrsMetamodelChangedProcessorTestCase {
 	public JaxrsMetamodelMonitor metamodelMonitor = new JaxrsMetamodelMonitor("org.jboss.tools.ws.jaxrs.tests.sampleproject", false);
 	
 	@Rule
-	public TestWatcher watcher = new TestWatcher();
+	public TestBanner watcher = new TestBanner();
 	
 	private JaxrsMetamodel metamodel = null;
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/Jaxrs11MetamodelTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/Jaxrs11MetamodelTestCase.java
@@ -35,7 +35,7 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.jboss.tools.ws.jaxrs.core.jdt.Flags;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementCategory;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsElement;
@@ -61,7 +61,7 @@ public class Jaxrs11MetamodelTestCase {
 	public JaxrsMetamodelMonitor metamodelMonitor = new JaxrsMetamodelMonitor("org.jboss.tools.ws.jaxrs.tests.sampleproject", true);
 	
 	@Rule
-	public TestWatcher watcher = new TestWatcher();
+	public TestBanner watcher = new TestBanner();
 	
 	private JaxrsMetamodel metamodel = null;
 	

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/Jaxrs20MetamodelTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/Jaxrs20MetamodelTestCase.java
@@ -12,7 +12,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IType;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.TestLogger;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsElement;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsNameBinding;
@@ -36,7 +36,7 @@ public class Jaxrs20MetamodelTestCase {
 	public JaxrsMetamodelMonitor metamodelMonitor = new JaxrsMetamodelMonitor(
 			"org.jboss.tools.ws.jaxrs.tests.sampleproject2", true);
 	@Rule
-	public TestWatcher watcher = new TestWatcher();
+	public TestBanner watcher = new TestBanner();
 	private JaxrsMetamodel metamodel = null;
 
 	@Before

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/indexation/LuceneIndexationTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/indexation/LuceneIndexationTestCase.java
@@ -62,7 +62,7 @@ public class LuceneIndexationTestCase {
 	private StandardAnalyzer analyzer;
 
 	private Map<String, IJaxrsElement> elements = new HashMap<String, IJaxrsElement>();
-	private IndexWriterConfig config = new IndexWriterConfig(Version.LUCENE_35, analyzer);
+	private IndexWriterConfig config = null;
 
 	@ClassRule
 	public static WorkspaceSetupRule workspaceSetupRule = new WorkspaceSetupRule("org.jboss.tools.ws.jaxrs.tests.sampleproject");
@@ -74,6 +74,7 @@ public class LuceneIndexationTestCase {
 	public void setup() throws CoreException, CorruptIndexException, IOException {
 		metamodelMonitor.getMetamodel();
 		analyzer = new StandardAnalyzer(Version.LUCENE_35);
+		config = new IndexWriterConfig(Version.LUCENE_35, analyzer);
 		index = new RAMDirectory();
 		w = new IndexWriter(index, config);
 		w.commit();

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/Jaxrs20ElementsSearcherTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/Jaxrs20ElementsSearcherTestCase.java
@@ -15,7 +15,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsParameterAgg
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.search.JavaElementsSearcher;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -32,7 +32,7 @@ public class Jaxrs20ElementsSearcherTestCase {
 			"org.jboss.tools.ws.jaxrs.tests.sampleproject2", false);
 
 	@Rule
-	public TestWatcher testWatcher = new TestWatcher();
+	public TestBanner testWatcher = new TestBanner();
 
 	private IJavaProject javaProject = null;
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtilsTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/jdt/JdtUtilsTestCase.java
@@ -61,7 +61,7 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JavaMethodSignature;
 import org.jboss.tools.ws.jaxrs.core.internal.utils.TestLogger;
 import org.jboss.tools.ws.jaxrs.core.junitrules.TestProjectMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJavaMethodParameter;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJavaMethodSignature;
@@ -79,7 +79,7 @@ public class JdtUtilsTestCase {
 	public static WorkspaceSetupRule workspaceSetupRule = new WorkspaceSetupRule("org.jboss.tools.ws.jaxrs.tests.sampleproject");
 	
 	@Rule
-	public TestWatcher testWatcher = new TestWatcher();
+	public TestBanner testWatcher = new TestBanner();
 	
 	@Rule
 	public TestProjectMonitor projectMonitor = new TestProjectMonitor("org.jboss.tools.ws.jaxrs.tests.sampleproject");

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JavaElementsUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JavaElementsUtils.java
@@ -398,7 +398,7 @@ public class JavaElementsUtils {
 						new NullProgressMonitor());
 				// Commit changes
 				TestLogger.debug("Commiting working copy...");
-				unit.commitWorkingCopy(true, null);
+				unit.commitWorkingCopy(false, null);
 				// Destroy working copy
 				TestLogger.debug("Discarding working copy...");
 				unit.discardWorkingCopy();

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
@@ -28,6 +28,7 @@ import org.jboss.tools.ws.jaxrs.core.JBossJaxrsCorePlugin;
 import org.jboss.tools.ws.jaxrs.core.configuration.ProjectBuilderUtils;
 import org.jboss.tools.ws.jaxrs.core.configuration.ProjectNatureUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.JavaElementChangedEvent;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.JavaElementDeltaFilter;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsElementFactory;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsHttpMethod;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaApplication;
@@ -56,7 +57,6 @@ import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsResourceProperty;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsEndpointDelta;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelDelta;
-import org.jboss.tools.ws.jaxrs.core.utils.JaxrsClassnames;
 import org.jboss.tools.ws.jaxrs.core.wtp.WtpUtils;
 
 /**
@@ -65,8 +65,6 @@ import org.jboss.tools.ws.jaxrs.core.wtp.WtpUtils;
  */
 public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsMetamodelChangedListener, IJaxrsElementChangedListener {
 	
-	public final static int ANY_EVENT_TYPE = 0;
-
 	public final static int NO_FLAG = 0;
 
 	private JaxrsMetamodel metamodel;
@@ -209,7 +207,7 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 	}
 
 	public void processEvent(final Annotation annotation, final int deltaKind) throws CoreException {
-		final JavaElementChangedEvent delta = new JavaElementChangedEvent(annotation.getJavaAnnotation(), deltaKind, ANY_EVENT_TYPE,
+		final JavaElementChangedEvent delta = new JavaElementChangedEvent(annotation.getJavaAnnotation(), deltaKind, JavaElementDeltaFilter.ANY_EVENT,
 				JdtUtils.parse(((IMember) annotation.getJavaParent()), new NullProgressMonitor()), Flags.NONE);
 		metamodel.processJavaElementChange(delta, new NullProgressMonitor());
 	}
@@ -219,7 +217,7 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 	}
 	
 	public void processEvent(final IJavaElement element, final int deltaKind, final Flags flags) throws CoreException {
-		final JavaElementChangedEvent delta = new JavaElementChangedEvent(element, deltaKind, ANY_EVENT_TYPE, JdtUtils.parse(element,
+		final JavaElementChangedEvent delta = new JavaElementChangedEvent(element, deltaKind, JavaElementDeltaFilter.ANY_EVENT, JdtUtils.parse(element,
 				new NullProgressMonitor()), flags);
 		metamodel.processJavaElementChange(delta, new NullProgressMonitor());
 	}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestBanner.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestBanner.java
@@ -10,7 +10,7 @@ import org.junit.runner.Description;
  * @author xcoulon
  *
  */
-public class TestWatcher extends org.junit.rules.TestWatcher {
+public class TestBanner extends org.junit.rules.TestWatcher {
 
 	protected void starting(org.junit.runner.Description description) {
 		TestLogger.debug("***********************************************");

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20BeanParamValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20BeanParamValidatorTestCase.java
@@ -42,7 +42,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsParameterAgg
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JavaElementsUtils;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.ui.preferences.JaxrsPreferences;
 import org.junit.Before;
@@ -70,7 +70,7 @@ public class Jaxrs20BeanParamValidatorTestCase {
 			"org.jboss.tools.ws.jaxrs.tests.sampleproject2", false);
 
 	@Rule
-	public TestWatcher testWatcher = new TestWatcher();
+	public TestBanner testWatcher = new TestBanner();
 
 	private JaxrsMetamodel metamodel = null;
 	private IProject project = null;

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ParamConverterProviderTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ParamConverterProviderTestCase.java
@@ -44,7 +44,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResource;
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.jdt.Flags;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementCategory;
 import org.jboss.tools.ws.jaxrs.ui.JBossJaxrsUIPlugin;
@@ -76,7 +76,7 @@ public class Jaxrs20ParamConverterProviderTestCase {
 			"org.jboss.tools.ws.jaxrs.tests.sampleproject2", false);
 	
 	@Rule
-	public TestWatcher testWatcher = new TestWatcher();
+	public TestBanner testWatcher = new TestBanner();
 	
 	private JaxrsMetamodel metamodel = null;
 	private IProject project = null;

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ProviderValidatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/internal/validation/Jaxrs20ProviderValidatorTestCase.java
@@ -60,7 +60,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsResourceMeth
 import org.jboss.tools.ws.jaxrs.core.jdt.Annotation;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
 import org.jboss.tools.ws.jaxrs.core.junitrules.LogListener;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementCategory;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.IJaxrsApplication;
@@ -96,7 +96,7 @@ public class Jaxrs20ProviderValidatorTestCase {
 	private IJavaProject javaProject = null;
 
 	@Rule
-	public TestWatcher watcher = new TestWatcher();
+	public TestBanner watcher = new TestBanner();
 
 	@Before
 	public void setup() throws CoreException {

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/quickfix/RetentionAnnotationMarkerResolutionTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/quickfix/RetentionAnnotationMarkerResolutionTestCase.java
@@ -43,7 +43,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsHttpMethod;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsNameBinding;
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
-import org.jboss.tools.ws.jaxrs.core.junitrules.TestWatcher;
+import org.jboss.tools.ws.jaxrs.core.junitrules.TestBanner;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.EnumElementCategory;
 import org.jboss.tools.ws.jaxrs.ui.internal.utils.TestLogger;
@@ -72,7 +72,7 @@ public class RetentionAnnotationMarkerResolutionTestCase {
 	public JaxrsMetamodelMonitor metamodelMonitor = new JaxrsMetamodelMonitor("org.jboss.tools.ws.jaxrs.tests.sampleproject2", false);
 	
 	@Rule
-	public TestWatcher watcher = new TestWatcher();
+	public TestBanner watcher = new TestBanner();
 	
 	private JaxrsMetamodel metamodel = null;
 


### PR DESCRIPTION
Accepting and processing events of type POST_CHANGE and POST_RECONCILE as one or the other
happens, depending if the change and save occurred at the same time (almost) or not.
