### PR TITLE
JBIDE-15825 - JAX-RS problems don't show up after target runtime is set

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilter.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaFilter.java
@@ -21,7 +21,7 @@ import static org.eclipse.jdt.core.IJavaElement.PACKAGE_FRAGMENT_ROOT;
 import static org.eclipse.jdt.core.IJavaElement.TYPE;
 import static org.eclipse.jdt.core.IJavaElementDelta.ADDED;
 import static org.eclipse.jdt.core.IJavaElementDelta.CHANGED;
-import static org.eclipse.jdt.core.IJavaElementDelta.F_ADDED_TO_CLASSPATH;
+import static org.eclipse.jdt.core.IJavaElementDelta.*;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_AST_AFFECTED;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_CONTENT;
 import static org.eclipse.jdt.core.IJavaElementDelta.F_FINE_GRAINED;
@@ -64,6 +64,7 @@ public class JavaElementDeltaFilter {
 		accept().when(JAVA_PROJECT).is(ADDED).after(POST_RECONCILE).in(PRIMARY_COPY);
 		accept().when(JAVA_PROJECT).is(REMOVED).after(POST_RECONCILE).in(PRIMARY_COPY);
 		accept().when(JAVA_PROJECT).is(CHANGED).withFlags(F_OPENED).after(POST_CHANGE).in(PRIMARY_COPY);
+		accept().when(JAVA_PROJECT).is(CHANGED).withFlags(F_CONTENT+F_CHILDREN+F_CLASSPATH_CHANGED+F_RESOLVED_CLASSPATH_CHANGED).after(POST_CHANGE).in(PRIMARY_COPY);
 
 		accept().when(PACKAGE_FRAGMENT_ROOT).is(ADDED).after(POST_CHANGE).in(PRIMARY_COPY);
 		accept().when(PACKAGE_FRAGMENT_ROOT).is(ADDED).withFlags(F_ADDED_TO_CLASSPATH).after(POST_CHANGE)

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScanner.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScanner.java
@@ -93,7 +93,7 @@ public class JavaElementDeltaScanner {
 		if (element == null) {
 			Logger.debug("** skipping this build because the delta element is null **");
 			return Collections.emptyList();
-		} else if(element.getElementType() == IJavaElement.JAVA_PROJECT && !element.getJavaProject().isOpen() && delta.getFlags() != F_OPENED) {
+		} else if(element.getElementType() == IJavaElement.JAVA_PROJECT && !element.getJavaProject().getProject().isOpen() && delta.getFlags() != F_OPENED) {
 			Logger.debug("** skipping this build because the java project is closed. **");
 			return Collections.emptyList();
 		} else if ((element.getElementType() == IJavaElement.PACKAGE_FRAGMENT_ROOT)) {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/ResourceDeltaFilter.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/ResourceDeltaFilter.java
@@ -20,7 +20,7 @@ import org.jboss.tools.ws.jaxrs.core.internal.utils.Logger;
 
 public class ResourceDeltaFilter {
 
-	public boolean applyRules(ResourceDelta event) throws JavaModelException {
+	public boolean applyRules(final ResourceDelta event) throws JavaModelException {
 		final IResource resource = event.getResource();
 		// prevent processing resources in a closed project
 		if (!resource.getProject().isOpen()) {

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/validation/ValidationUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/validation/ValidationUtils.java
@@ -1,0 +1,27 @@
+/******************************************************************************* 
+ * Copyright (c) 2008 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Xavier Coulon - Initial API and implementation 
+ ******************************************************************************/
+
+package org.jboss.tools.ws.jaxrs.core.validation;
+
+/**
+ * @author xcoulon
+ *
+ */
+public class ValidationUtils {
+
+	/**
+	 * 
+	 */
+	public ValidationUtils() {
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
@@ -29,6 +29,7 @@ import org.jboss.tools.ws.jaxrs.core.configuration.ProjectBuilderUtils;
 import org.jboss.tools.ws.jaxrs.core.configuration.ProjectNatureUtils;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.JavaElementChangedEvent;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.JavaElementDeltaFilter;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.builder.ResourceDelta;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsElementFactory;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsHttpMethod;
 import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsJavaApplication;
@@ -206,6 +207,15 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 		this.metamodelProblemLevelChanges.clear();
 	}
 
+	public void processProject() throws CoreException {
+		metamodel.processProject(new NullProgressMonitor());
+		
+	}
+	
+	public void processResourceEvent(final IResource resource, final int deltaKind) throws CoreException {
+		metamodel.processAffectedResources(Arrays.asList(new ResourceDelta(resource, deltaKind, Flags.NONE)), new NullProgressMonitor());
+	}
+	
 	public void processEvent(final Annotation annotation, final int deltaKind) throws CoreException {
 		final JavaElementChangedEvent delta = new JavaElementChangedEvent(annotation.getJavaAnnotation(), deltaKind, JavaElementDeltaFilter.ANY_EVENT,
 				JdtUtils.parse(((IMember) annotation.getJavaParent()), new NullProgressMonitor()), Flags.NONE);

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestProjectMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestProjectMonitor.java
@@ -212,6 +212,30 @@ public class TestProjectMonitor extends ExternalResource {
 	}
 	
 	/**
+	 * Removes the underlying {@link IResource} of the {@link IPackageFragmentRoot} matching the given {@code path}.
+	 * @param path
+	 * @throws JavaModelException
+	 * @throws CoreException
+	 */
+	public void removePackageFragmentRoot(final String path) throws JavaModelException, CoreException {
+		resolvePackageFragmentRoot(path).getResource().delete(true, null);
+	}
+	
+	/**
+	 * Removes the underlying {@link IResource} matching the given {@code path}.
+	 * @param path
+	 * @throws JavaModelException
+	 * @throws CoreException
+	 */
+	public void removeFolder(final String... pathFragments) throws JavaModelException, CoreException {
+		IPath path = project.getProjectRelativePath();
+		for(String pathFragment : pathFragments) {
+			path = path.append(pathFragment);
+		}
+		project.findMember(path).delete(true, null);
+	}
+	
+	/**
 	 * Remove the first referenced library those absolute path contains the
 	 * given name.
 	 * 


### PR DESCRIPTION
Main changes:
    - handle changes at the project level when the classpath changed: rebuild the whoe JAX-RS metamodel to be process all the changes
    - remove all JAX-RS markers of previous JAX-RS elements when rebuilding the while JAX-RS metamodel in a separate Job while the resource tree
      is locked.

```
Related changes:
- added some unit tests
- refactored a unit test class
```
