### PR TITLE
JBIDE-18453 - NPE while processing change in code

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScanner.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScanner.java
@@ -127,19 +127,13 @@ public class JavaElementDeltaScanner {
 				// (renaming, adding/removing params) result in add+remove
 				// events on the given method itself.
 				if(requiresDiffsComputation(flags)) {
-					final Map<String, JavaMethodSignature> diffs = new HashMap<String, JavaMethodSignature>();
 					for(IType type : compilationUnit.getAllTypes()) {
-						for(IMethod method : type.getMethods()) {
-							diffs.put(method.getHandleIdentifier(), JdtUtils.resolveMethodSignature(method, compilationUnitAST));
-						}
-					}
-					
-					for (Entry<String, JavaMethodSignature> diff : diffs.entrySet()) {
-						final IJavaMethodSignature methodSignature = diff.getValue();
-						final JavaElementChangedEvent event = new JavaElementChangedEvent(methodSignature.getJavaMethod(), CHANGED, eventType,
-								compilationUnitAST, new Flags(F_SIGNATURE));
-						if (javaElementChangedEventFilter.apply(event)) {
-							events.add(event);
+						for(IMethod javaMethod : type.getMethods()) {
+							final JavaElementChangedEvent event = new JavaElementChangedEvent(javaMethod, CHANGED, eventType,
+									compilationUnitAST, new Flags(F_SIGNATURE));
+							if (javaElementChangedEventFilter.apply(event)) {
+								events.add(event);
+							}
 						}
 					}
 				}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScannerTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/builder/JavaElementDeltaScannerTestCase.java
@@ -1182,4 +1182,5 @@ public class JavaElementDeltaScannerTestCase {
 		// verification
 		verify(resourceEvents, never()).add(new ResourceDelta(project, CHANGED, Flags.NONE));
 	}
+	
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpointTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsEndpointTestCase.java
@@ -14,6 +14,7 @@ package org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
+import static org.jboss.tools.ws.jaxrs.core.junitrules.JavaElementsUtils.getWorkspace;
 import static org.jboss.tools.ws.jaxrs.core.junitrules.ResourcesUtils.replaceFirstOccurrenceOfCode;
 import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_MATRIX_PARAM_ANNOTATION;
 import static org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta.F_PATH_ANNOTATION;
@@ -167,7 +168,7 @@ public class JaxrsEndpointTestCase {
 		resourceMethod.update(modifiedMethod, JdtUtils.parse(modifiedMethod, null));
 		final JaxrsEndpoint endpoint = metamodel.findEndpoints(resourceMethod).iterator().next();
 		endpoint.update(new Flags(F_PATH_ANNOTATION + F_QUERY_PARAM_ANNOTATION + F_MATRIX_PARAM_ANNOTATION));
-		WorkbenchTasks.waitForTasksToComplete(javaProject);
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(javaProject));
 		// verifications
 		final String uriPathTemplate = endpoint.getUriPathTemplate();
 		assertThat(
@@ -183,7 +184,7 @@ public class JaxrsEndpointTestCase {
 		resourceMethod.update(modifiedMethod, JdtUtils.parse(modifiedMethod, null));
 		final JaxrsEndpoint endpoint = metamodel.findEndpoints(resourceMethod).iterator().next();
 		endpoint.update(new Flags(F_PATH_ANNOTATION + F_QUERY_PARAM_ANNOTATION + F_MATRIX_PARAM_ANNOTATION));
-		WorkbenchTasks.waitForTasksToComplete(javaProject);
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(javaProject));
 		// verifications
 		final String uriPathTemplate = endpoint.getUriPathTemplate();
 		assertThat(

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JavaElementsUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JavaElementsUtils.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ILocalVariable;
@@ -409,7 +410,7 @@ public class JavaElementsUtils {
 			// explicitly trigger the project build
 			compilationUnit.getResource().refreshLocal(IResource.DEPTH_ONE, new NullProgressMonitor());
 			compilationUnit.getJavaProject().getProject().build(IncrementalProjectBuilder.AUTO_BUILD, null);
-			WorkbenchTasks.waitForTasksToComplete(compilationUnit.getJavaProject());
+			WorkbenchTasks.waitForTasksToComplete(getWorkspace(compilationUnit));
 		} catch (Exception e) {
 			TestLogger.error("Failed to build project", e);
 		}
@@ -417,7 +418,7 @@ public class JavaElementsUtils {
 
 	public static void delete(final ICompilationUnit compilationUnit) throws CoreException {
 		compilationUnit.delete(true, new NullProgressMonitor());
-		WorkbenchTasks.waitForTasksToComplete(compilationUnit.getJavaProject());
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(compilationUnit));
 	}
 
 	public static void delete(final IAnnotation annotation, final boolean useWorkingCopy) throws CoreException {
@@ -521,6 +522,15 @@ public class JavaElementsUtils {
 		}
 		return null;
 	}
+
+	/**
+	 * @return the {@link IWorkspace} associated with the given {@link IJavaElement}
+	 * @param javaElement the {@link IJavaElement} to process
+	 */
+	public static IWorkspace getWorkspace(final IJavaElement javaElement) {
+		return javaElement.getJavaProject().getProject().getWorkspace();
+	}
+
 
 		
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/JaxrsMetamodelMonitor.java
@@ -5,6 +5,8 @@ package org.jboss.tools.ws.jaxrs.core.junitrules;
 
 import static org.eclipse.jdt.core.ElementChangedEvent.POST_CHANGE;
 import static org.eclipse.jdt.core.ElementChangedEvent.POST_RECONCILE;
+import static org.jboss.tools.ws.jaxrs.core.junitrules.JavaElementsUtils.getWorkspace;
+import static org.jboss.tools.ws.jaxrs.core.junitrules.ResourcesUtils.getWorkspace;
 import static org.jboss.tools.ws.jaxrs.core.utils.JaxrsClassnames.APPLICATION_PATH;
 import static org.jboss.tools.ws.jaxrs.core.utils.JaxrsClassnames.HTTP_METHOD;
 import static org.junit.Assert.fail;
@@ -60,7 +62,6 @@ import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsElementDelta;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsEndpointDelta;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelDelta;
 import org.jboss.tools.ws.jaxrs.core.wtp.WtpUtils;
-
 /**
  * @author xcoulon
  *
@@ -212,11 +213,12 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 
 	public void processProject() throws CoreException {
 		metamodel.processProject(new NullProgressMonitor());
-		
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(getJavaProject()));
 	}
 	
 	public void processResourceEvent(final IResource resource, final int deltaKind) throws CoreException {
 		metamodel.processAffectedResources(Arrays.asList(new ResourceDelta(resource, deltaKind, Flags.NONE)), new NullProgressMonitor());
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(resource));
 	}
 	
 	/**
@@ -230,7 +232,7 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 		final JavaElementChangedEvent delta = new JavaElementChangedEvent(annotation.getJavaAnnotation(), deltaKind, POST_RECONCILE + POST_CHANGE,
 				JdtUtils.parse(((IMember) annotation.getJavaParent()), new NullProgressMonitor()), Flags.NONE);
 		metamodel.processJavaElementChange(delta, new NullProgressMonitor());
-		WorkbenchTasks.waitForTasksToComplete(annotation.getJavaAnnotation());
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(annotation.getJavaAnnotation()));
 	}
 	
 	/**
@@ -242,6 +244,7 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 	 */
 	public void processEvent(final IJavaElement element, final int deltaKind) throws CoreException {
 		processEvent(element, deltaKind, Flags.NONE);
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(element));
 	}
 	
 	/**
@@ -255,7 +258,7 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 		final JavaElementChangedEvent delta = new JavaElementChangedEvent(element, deltaKind, POST_RECONCILE + POST_CHANGE, JdtUtils.parse(element,
 				new NullProgressMonitor()), flags);
 		metamodel.processJavaElementChange(delta, new NullProgressMonitor());
-		WorkbenchTasks.waitForTasksToComplete(element);
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(element));
 	}
 	
 	/********************************************************************************************
@@ -275,7 +278,7 @@ public class JaxrsMetamodelMonitor extends TestProjectMonitor implements IJaxrsM
 		// remove the validation builder to avoid blocking during tests
 		ProjectBuilderUtils.uninstallProjectBuilder(getProject(), ProjectBuilderUtils.VALIDATOR_BUILDER_ID);
 		buildProject();		
-		WorkbenchTasks.waitForTasksToComplete(getJavaProject());
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(getJavaProject()));
 		return this.metamodel;
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/ResourcesUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/ResourcesUtils.java
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
@@ -121,7 +122,7 @@ public class ResourcesUtils {
 	 */
 	public static void delete(IResource resource) throws CoreException {
 		resource.delete(true, new NullProgressMonitor());
-		WorkbenchTasks.waitForTasksToComplete(resource.getProject());
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(resource));
 	}
 
 	/**
@@ -292,4 +293,11 @@ public class ResourcesUtils {
 		file.refreshLocal(IResource.DEPTH_ONE, null);
 	}
 
+	/**
+	 * @return the {@link IWorkspace} associated with the given {@link IResource}
+	 * @param resource the {@link IResource} to process
+	 */
+	public static IWorkspace getWorkspace(final IResource resource) {
+		return resource.getProject().getWorkspace();
+	}
 }

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestProjectMonitor.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/TestProjectMonitor.java
@@ -2,8 +2,8 @@
  * 
  */
 package org.jboss.tools.ws.jaxrs.core.junitrules;
-
 import static org.hamcrest.Matchers.notNullValue;
+import static org.jboss.tools.ws.jaxrs.core.junitrules.ResourcesUtils.getWorkspace;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -159,7 +159,7 @@ public class TestProjectMonitor extends ExternalResource {
 		project.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
 		project.build(buildKind, new NullProgressMonitor());
 		Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, null);
-		WorkbenchTasks.waitForTasksToComplete(project);
+		WorkbenchTasks.waitForTasksToComplete(getWorkspace(project));
 	}
 
 	/**
@@ -330,7 +330,7 @@ public class TestProjectMonitor extends ExternalResource {
 		ICompilationUnit foocompilationUnit = packageFragment.createCompilationUnit(unitName, contents, true,
 				new NullProgressMonitor());
 		JavaElementsUtils.saveAndClose(foocompilationUnit);
-		WorkbenchTasks.waitForTasksToComplete(javaProject);
+		WorkbenchTasks.waitForTasksToComplete(javaProject.getProject().getWorkspace());
 		return foocompilationUnit;
 	}
 

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/WorkbenchTasks.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/WorkbenchTasks.java
@@ -28,13 +28,9 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.ui.dialogs.IOverwriteQuery;
 import org.eclipse.ui.internal.ide.filesystem.FileSystemStructureProvider;
@@ -169,22 +165,14 @@ public class WorkbenchTasks {
 	}
 	
 	/**
-	 * Waits for internal jobs to complete before returning, to be sure that assertions will be performed *after* jobs are done.
-	 * @param element
+	 * Waits for workspace jobs to complete before returning, to be sure that assertions will be performed *after* jobs are done.
+	 * @param workspace the workspace
 	 */
-	public static void waitForTasksToComplete(final IJavaElement element) {
-		waitForTasksToComplete(element.getJavaProject().getProject());
-	}
-
-	/**
-	 * Waits for internal jobs to complete before returning, to be sure that assertions will be performed *after* jobs are done.
-	 * @param element
-	 */
-	public static void waitForTasksToComplete(final IProject project) {
+	public static void waitForTasksToComplete(final IWorkspace workspace) {
 		// trigger a fake job with a scheduling rule to make sure any other job did complete
 		try {
 			final TimeLimitedJob waitJob = new TimeLimitedJob();
-			waitJob.setRule(project.getWorkspace().getRuleFactory().buildRule());
+			waitJob.setRule(workspace.getRuleFactory().buildRule());
 			waitJob.scheduleWithTimeout(10*60);
 			waitJob.join();
 		} catch (InterruptedException e) {


### PR DESCRIPTION
Remove a block where the signature of the Java methods were collected but not used
(a remaining of a previous refactoring)
Added some 'waits' in the unit tests (with a bit of API refactoring in the test utility classes) because
some tests would fail with ConcurrentModificationException on maven (some elements would still be processed
in a separate thread when doing the test assertions)
