### PR TITLE
JBIDE-18392 - JAX-RS Resource wizard: Resource methods are created even ...

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsElementCreationUtils.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsElementCreationUtils.java
@@ -132,12 +132,12 @@ public class JaxrsElementCreationUtils {
 	}
 
 	/**
-	 * @param annotationFullyQualifiedName
-	 * @return
+	 * @param fullyQualifiedName
+	 * @return the simple name associated with the given fully qualified name
 	 */
-	public static String getSimpleName(final String annotationFullyQualifiedName) {
-		final int i = annotationFullyQualifiedName.lastIndexOf('.');
-		final String annotationSimpleName = annotationFullyQualifiedName.substring(i + 1);
+	public static String getSimpleName(final String fullyQualifiedName) {
+		final int i = fullyQualifiedName.lastIndexOf('.');
+		final String annotationSimpleName = fullyQualifiedName.substring(i + 1);
 		return annotationSimpleName;
 	}
 

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsResourceCreationWizardPage.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsResourceCreationWizardPage.java
@@ -752,6 +752,10 @@ public class JaxrsResourceCreationWizardPage extends NewClassWizardPage {
 
 	void createMethodStubs(final IType type, final ImportsManager imports, final IProgressMonitor monitor)
 			throws JavaModelException {
+		if(this.targetClass == null || this.targetClass.isEmpty()) {
+			// skipping if the user removed the target class in the wizard page (see JBIDE-18392)
+			return;
+		}
 		final String targetClassSimpleName = getSimpleName(this.targetClass);
 		final String targetClassParamName = targetClassSimpleName.toLowerCase();
 		if(this.targetClass != null && !this.targetClass.isEmpty()) {

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsResourceCreationWizardPageTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/src/org/jboss/tools/ws/jaxrs/ui/wizards/JaxrsResourceCreationWizardPageTestCase.java
@@ -213,6 +213,36 @@ public class JaxrsResourceCreationWizardPageTestCase {
 		assertThat(createdResource.getAllMethods().size(), equalTo(0));
 		assertThat(createdResource.getPathTemplate(), equalTo("/customers"));
 	}
+
+	@Test
+	public void shouldCreateResourceClassWithNoMethodWhenNoTargetClass() throws CoreException, InterruptedException {
+		// given
+		final JaxrsResourceCreationWizardPage wizardPage = new JaxrsResourceCreationWizardPage();
+		final IType customerType = JdtUtils.resolveType("org.jboss.tools.ws.jaxrs.sample.domain.Customer", javaProject,
+				new NullProgressMonitor());
+		final IStructuredSelection selection = new StructuredSelection(customerType);
+		// when
+		wizardPage.init(selection);
+		wizardPage.setIncludeCreateMethod(true);
+		wizardPage.setIncludeDeleteByIdMethod(true);
+		wizardPage.setIncludeFindByIdMethod(true);
+		wizardPage.setIncludeListAllMethod(true);
+		wizardPage.setIncludeUpdateMethod(true);
+		// remove the target class
+		wizardPage.setTargetClass("");
+		wizardPage.createType(new NullProgressMonitor());
+		// then
+		final IType createdType = wizardPage.getCreatedType();
+		assertThat(createdType, notNullValue());
+		assertThat(createdType.getMethods().length, equalTo(0));
+		// trigger a clean build before asserting the new JAX-RS elements
+		metamodelMonitor.buildProject(IncrementalProjectBuilder.FULL_BUILD);
+		// 6 new elements: 1 resource + 5 resource methods
+		final IJaxrsResource createdResource = (IJaxrsResource) metamodel.findElement(createdType);
+		assertThat(createdResource, notNullValue());
+		assertThat(createdResource.getAllMethods().size(), equalTo(0));
+		assertThat(createdResource.getPathTemplate(), equalTo("/customers"));
+	}
 	
 	@Test
 	public void shouldCreateResourceClassWithCreateMethod() throws CoreException, InterruptedException {


### PR DESCRIPTION
...though there is no Target entity specified anymore

Fixed the problem by skipping method generation if no target entity was specified
Added a JUnit test to cover that case
