### PR TITLE
JBIDE-18913 - Build failures after renaming of some 'server' bundles

### DIFF
--- a/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/AbstractJBossWSGenerationTest.java
+++ b/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/AbstractJBossWSGenerationTest.java
@@ -71,7 +71,7 @@ public class AbstractJBossWSGenerationTest extends TestCase {
 	}
 	
 	public void createWSServer() throws Exception {
-		currentServer = ServerCreationTestUtils.createServerWithRuntime(IJBossToolingConstants.SERVER_AS_42, getClass().getName());		
+		currentServer = ServerCreationTestUtils.createServerWithRuntime(IJBossToolingConstants.SERVER_AS_42, IJBossToolingConstants.SERVER_AS_42);		
 	}
 
 	public IProject createProject(String prjName) throws CoreException {
@@ -154,7 +154,7 @@ public class AbstractJBossWSGenerationTest extends TestCase {
 	}
 
 	protected void startup(IServer server) {
-		StartupShutdownUtil.shutdown(server);
+		StartupShutdownUtil.startup(server);
 	}
 	
 	protected void shutdown(IServer server) {

--- a/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/JBossWSJavaFirstCommandTest.java
+++ b/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/JBossWSJavaFirstCommandTest.java
@@ -150,7 +150,8 @@ public class JBossWSJavaFirstCommandTest extends AbstractJBossWSGenerationTest {
 			if (console.getName().contains("ClientSample")) {
 				int i = 0;
 				while (i < 30&& !isContainString(console,JBossWSCreationCoreMessages.Client_Sample_Run_Over)) {
-					JBossWSCreationCoreTestUtils.delay(1000);
+					JobUtils.delay(1000);
+					//JBossWSCreationCoreTestUtils.delay(1000);
 					i++;
 				}
 				assertTrue(((TextConsole) console).getDocument().get(),isContainString(console,JBossWSCreationCoreMessages.Client_Sample_Run_Over));


### PR DESCRIPTION
Fixing a bug in a test and using a different method to wait for changes in the console
