### PR TITLE
JBIDE-20432 - o.j.t.websocket.feature has empty requires element

### DIFF
--- a/features/org.jboss.tools.websockets.feature/feature.xml
+++ b/features/org.jboss.tools.websockets.feature/feature.xml
@@ -20,9 +20,6 @@
       %license
    </license>
 
-   <requires>
-   </requires>
-
    <plugin
          id="org.jboss.tools.websockets.core"
          download-size="0"


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-20432
o.j.t.websocket.feature has empty requires element