### PR TITLE
JBIDE-20608 - Build failures on Jenkins on other OS

### DIFF
--- a/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/JBossWSCreationCoreTestSuite.java
+++ b/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/JBossWSCreationCoreTestSuite.java
@@ -11,27 +11,21 @@
 
 package org.jboss.tools.ws.creation.core.test;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-
 import org.jboss.tools.ws.creation.core.test.command.JBossWSClientCommandTest;
 import org.jboss.tools.ws.creation.core.test.command.JBossWSClientSampleCreationCommandTest;
 import org.jboss.tools.ws.creation.core.test.command.JBossWSJavaFirstCommandTest;
 import org.jboss.tools.ws.creation.core.test.command.JBossWSMergeWebXMLCommandTest;
 import org.jboss.tools.ws.creation.core.test.command.JBossWSTopDownCommandTest;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-public class JBossWSCreationCoreTestSuite extends TestCase {
-	public static final String PLUGIN_ID = "org.jboss.tools.ws.creation.core.test";
-	public static Test suite ()
-	{
-		TestSuite suite = new TestSuite(JBossWSCreationCoreTestSuite.class.getName());
-		suite.addTestSuite(JBossWSTopDownCommandTest.class);
-		suite.addTestSuite(JBossWSJavaFirstCommandTest.class);
-		suite.addTestSuite(JBossWSClientCommandTest.class);
-		suite.addTestSuite(JBossWSMergeWebXMLCommandTest.class);
-		suite.addTestSuite(JBossWSClientSampleCreationCommandTest.class);
-
-		return suite;
-	}
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	JBossWSTopDownCommandTest.class,
+	JBossWSJavaFirstCommandTest.class,
+	JBossWSClientCommandTest.class,
+	JBossWSMergeWebXMLCommandTest.class,
+	JBossWSClientSampleCreationCommandTest.class
+})
+public class JBossWSCreationCoreTestSuite {
 }

--- a/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/AbstractJBossWSGenerationTest.java
+++ b/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/AbstractJBossWSGenerationTest.java
@@ -14,8 +14,6 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -48,9 +46,15 @@ import org.jboss.tools.ws.core.facet.delegate.IJBossWSFacetDataModelProperties;
 import org.jboss.tools.ws.core.facet.delegate.JBossWSFacetInstallDataModelProvider;
 import org.jboss.tools.ws.creation.core.data.ServiceModel;
 import org.jboss.tools.ws.creation.core.test.util.StartupShutdownUtil;
+import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
-public class AbstractJBossWSGenerationTest extends TestCase {
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class AbstractJBossWSGenerationTest {
 	protected IServer currentServer;
 	protected final Set<IResource> resourcesToCleanup = new HashSet<IResource>();
 	static String BUNDLE = "org.jboss.tools.ws.creation.core.test";
@@ -63,8 +67,14 @@ public class AbstractJBossWSGenerationTest extends TestCase {
 	IFacetedProject fproject;
 	public IFile wsdlFile;
 
+	@BeforeClass
+	public static void skipOnMacOS() {
+		final String os = System.getProperty("os.name").toLowerCase();
+		Assume.assumeFalse("Skipping MacOSX/JRE5 combination", os.startsWith("mac os"));
+	}
+
 	@Before
-	public void setUp() throws Exception{
+	public void setUp() throws Exception {
 		assertNotNull(TestConstants.JRE_5_HOME, "No JRE5 property in System");
 		assertTrue("The JRE5 location is not right", new Path(TestConstants.JRE_5_HOME).toFile().exists());
 		JavaRuntime.setDefaultVMInstall(JREUtils.createJRE(new Path(TestConstants.JRE_5_HOME)), new NullProgressMonitor() );
@@ -142,6 +152,7 @@ public class AbstractJBossWSGenerationTest extends TestCase {
 		return false;
 	}
 	
+	@After
 	public void tearDown() throws Exception{
 		cleanResouces();
 		JBossWSRuntime runtime = JBossWSRuntimeManager.getInstance().findRuntimeByName(RuntimeName);
@@ -153,7 +164,6 @@ public class AbstractJBossWSGenerationTest extends TestCase {
 		} catch( CoreException ce ) {
 			// report
 		}
-		super.tearDown();
 	}
 
 	protected void startup(IServer server) {

--- a/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/JBossWSClientSampleCreationCommandTest.java
+++ b/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/JBossWSClientSampleCreationCommandTest.java
@@ -10,11 +10,7 @@
  ******************************************************************************/ 
 package org.jboss.tools.ws.creation.core.test.command;
 
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IProject;
@@ -29,6 +25,8 @@ import org.jboss.tools.ws.creation.core.utils.JBossWSCreationUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import junit.framework.TestCase;
 
 public class JBossWSClientSampleCreationCommandTest extends TestCase {
 	static String BUNDLE = "org.jboss.tools.ws.creation.core.test";

--- a/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/JBossWSJavaFirstCommandTest.java
+++ b/tests/org.jboss.tools.ws.creation.core.test/src/org/jboss/tools/ws/creation/core/test/command/JBossWSJavaFirstCommandTest.java
@@ -19,22 +19,17 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfigurationType;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
-import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.TextConsole;
 import org.eclipse.wst.ws.internal.wsrt.IWebService;
 import org.eclipse.wst.ws.internal.wsrt.WebServiceInfo;
 import org.eclipse.wst.ws.internal.wsrt.WebServiceScenario;
-import org.jboss.tools.as.test.core.TestConstants;
-import org.jboss.tools.as.test.core.internal.utils.JREUtils;
 import org.jboss.tools.test.util.JobUtils;
 import org.jboss.tools.ws.creation.core.commands.InitialCommand;
 import org.jboss.tools.ws.creation.core.commands.Java2WSCommand;
@@ -61,7 +56,6 @@ public class JBossWSJavaFirstCommandTest extends AbstractJBossWSGenerationTest {
 	@Before
 	@Override
 	public void setUp() throws Exception {
-		JREUtils.createJRE(new Path(TestConstants.JRE_5_HOME));
 		super.setUp();
 
 		//create jbossws web project

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/ResourcesUtils.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/junitrules/ResourcesUtils.java
@@ -207,21 +207,8 @@ public class ResourcesUtils {
 		assertNotEquals("Could not find occurrence of" + oldContent + "\nin\n" + content, content.indexOf(oldContent), -1);
 		// operation
 		final String modifiedContent = content.replace(oldContent, newContent);
-		file.delete(true, new NullProgressMonitor());
-		file.create(IOUtils.toInputStream(modifiedContent), true, null);
-		final InputStream contents = file.getContents();
-		final char[] buffer = new char[0x10000];
-		final StringBuilder out = new StringBuilder();
-		final Reader in = new InputStreamReader(contents, "UTF-8");
-		int read;
-		do {
-			read = in.read(buffer, 0, buffer.length);
-			if (read > 0) {
-				out.append(buffer, 0, read);
-			}
-		} while (read >= 0);
-		in.close();
-		TestLogger.debug("Content:\n" + out.toString());
+		file.setContents(IOUtils.toInputStream(modifiedContent), true, false, null);
+		TestLogger.debug("Content:\n" + modifiedContent);
 	}
 
 	/**


### PR DESCRIPTION
Using org.junit.Assume to skip tests on MacOSX since JRE5 is
not available on that OS anymore
Do not remove and re-create file during JAX-RS test when the
goal is just to change the content of the file.