### PR TITLE
JBIDE-22567 - For JBIDE 4.4.1.Alpha1: Prepare for 4.4.1.Alpha1

### DIFF
--- a/features/org.jboss.tools.websockets.feature/feature.xml
+++ b/features/org.jboss.tools.websockets.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.websockets.feature"
       label="%featureName"
-      version="1.9.0.qualifier"
+      version="1.9.1.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.websockets.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.jboss.tools.websockets.feature/pom.xml
+++ b/features/org.jboss.tools.websockets.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.features</groupId>
 	<artifactId>org.jboss.tools.websockets.feature</artifactId>

--- a/features/org.jboss.tools.websockets.test.feature/feature.xml
+++ b/features/org.jboss.tools.websockets.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature 
     id="org.jboss.tools.websockets.test.feature" 
     label="%featureName"
-    version="1.9.0.qualifier"
+    version="1.9.1.qualifier"
     provider-name="%featureProvider"
     license-feature="org.jboss.tools.foundation.license.feature"
     license-feature-version="0.0.0">

--- a/features/org.jboss.tools.websockets.test.feature/pom.xml
+++ b/features/org.jboss.tools.websockets.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.features</groupId>
 	<artifactId>org.jboss.tools.websockets.test.feature</artifactId>

--- a/features/org.jboss.tools.ws.feature/feature.xml
+++ b/features/org.jboss.tools.ws.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.ws.feature"
       label="%featureName"
-      version="1.9.0.qualifier"
+      version="1.9.1.qualifier"
       provider-name="%providerName"
       plugin="org.jboss.tools.ws.ui"
       license-feature="org.jboss.tools.foundation.license.feature"

--- a/features/org.jboss.tools.ws.feature/pom.xml
+++ b/features/org.jboss.tools.ws.feature/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.features</groupId>
 	<artifactId>org.jboss.tools.ws.feature</artifactId>

--- a/features/org.jboss.tools.ws.jaxrs.feature/feature.xml
+++ b/features/org.jboss.tools.ws.jaxrs.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.tools.ws.jaxrs.feature"
       label="%featureName"
-      version="1.9.0.qualifier"
+      version="1.9.1.qualifier"
       provider-name="%providerName"
       license-feature="org.jboss.tools.foundation.license.feature"
       license-feature-version="0.0.0">

--- a/features/org.jboss.tools.ws.jaxrs.feature/pom.xml
+++ b/features/org.jboss.tools.ws.jaxrs.feature/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.features</groupId>
 	<artifactId>org.jboss.tools.ws.jaxrs.feature</artifactId>

--- a/features/org.jboss.tools.ws.test.feature/feature.xml
+++ b/features/org.jboss.tools.ws.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature 
     id="org.jboss.tools.ws.test.feature"
     label="%featureName"
-    version="1.9.0.qualifier"
+    version="1.9.1.qualifier"
     provider-name="%featureProvider"
     license-feature="org.jboss.tools.foundation.license.feature"
     license-feature-version="0.0.0">

--- a/features/org.jboss.tools.ws.test.feature/pom.xml
+++ b/features/org.jboss.tools.ws.test.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>features</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.features</groupId>
 	<artifactId>org.jboss.tools.ws.test.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>ws</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.tools.websockets.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.websockets.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.jboss.tools.websockets.core;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.jboss.tools.websockets.core.WebsocketsCorePlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/plugins/org.jboss.tools.websockets.core/pom.xml
+++ b/plugins/org.jboss.tools.websockets.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.websockets.core</artifactId>

--- a/plugins/org.jboss.tools.websockets.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.websockets.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.jboss.tools.websockets.ui;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.websockets.ui.WebsocketsUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/plugins/org.jboss.tools.websockets.ui/pom.xml
+++ b/plugins/org.jboss.tools.websockets.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.websockets.ui</artifactId>

--- a/plugins/org.jboss.tools.ws.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.jboss.tools.ws.core;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Localization: plugin
 Bundle-Activator: org.jboss.tools.ws.core.JBossWSCorePlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/plugins/org.jboss.tools.ws.core/pom.xml
+++ b/plugins/org.jboss.tools.ws.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.ws.core</artifactId>

--- a/plugins/org.jboss.tools.ws.creation.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.creation.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.ws.creation.core;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.creation.core.JBossWSCreationCorePlugin
 Bundle-Vendor: %Bundle-Vendor.0
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/plugins/org.jboss.tools.ws.creation.core/pom.xml
+++ b/plugins/org.jboss.tools.ws.creation.core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.ws.creation.core</artifactId>

--- a/plugins/org.jboss.tools.ws.creation.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.creation.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.jboss.tools.ws.creation.ui;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.creation.ui.JBossWSCreationUIPlugin
 Bundle-Vendor: %PLUGIN_PROVIDER
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/plugins/org.jboss.tools.ws.creation.ui/pom.xml
+++ b/plugins/org.jboss.tools.ws.creation.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.ws.creation.ui</artifactId>

--- a/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Localization: plugin
 Bundle-Name: %PLUGIN_NAME
 Bundle-Vendor: %PLUGIN_PROVIDER
 Bundle-SymbolicName: org.jboss.tools.ws.jaxrs.core;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.jaxrs.core.JBossJaxrsCorePlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0";visibility:=reexport,
  org.eclipse.core.resources;bundle-version="3.7.100";visibility:=reexport,

--- a/plugins/org.jboss.tools.ws.jaxrs.core/pom.xml
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.ws.jaxrs.core</artifactId>

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Localization: plugin
 Bundle-Name: %PLUGIN_NAME
 Bundle-Vendor: %PLUGIN_PROVIDER
 Bundle-SymbolicName: org.jboss.tools.ws.jaxrs.ui;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.jaxrs.ui.JBossJaxrsUIPlugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.ui.ide;bundle-version="3.12.0",

--- a/plugins/org.jboss.tools.ws.jaxrs.ui/pom.xml
+++ b/plugins/org.jboss.tools.ws.jaxrs.ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.ws.jaxrs.ui</artifactId>

--- a/plugins/org.jboss.tools.ws.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %PLUGIN_NAME
 Bundle-SymbolicName: org.jboss.tools.ws.ui;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.ui.JBossWSUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",

--- a/plugins/org.jboss.tools.ws.ui/pom.xml
+++ b/plugins/org.jboss.tools.ws.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.plugins</groupId>
 	<artifactId>org.jboss.tools.ws.ui</artifactId>

--- a/plugins/org.jboss.tools.ws.wise.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.wise.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Wise UI Plug-in Wrapper
 Bundle-SymbolicName: org.jboss.tools.ws.wise.ui;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.tools.ws.wise.ui/pom.xml
+++ b/plugins/org.jboss.tools.ws.wise.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.jboss.tools.ws.wise.ui</artifactId>
 	

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>ws</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.4.0.Final-SNAPSHOT</version>
+		<version>4.4.1.Alpha1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools</groupId>
 	<artifactId>ws</artifactId>
 	<name>jbosstools-webservices</name>
-	<version>1.9.0-SNAPSHOT</version>
+	<version>1.9.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
 		<tycho.scmUrl>scm:git:https://github.com/jbosstools/jbosstools-webservices.git</tycho.scmUrl>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>ws</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>ws.site</artifactId>

--- a/tests/org.jboss.tools.websockets.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.websockets.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.websockets.ui.test;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.websockets.ui.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.websockets.ui.test/pom.xml
+++ b/tests/org.jboss.tools.websockets.ui.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.websockets.ui.test</artifactId>

--- a/tests/org.jboss.tools.ws.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.ws.core.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.core.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ws.core.test/pom.xml
+++ b/tests/org.jboss.tools.ws.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.core.test</artifactId>

--- a/tests/org.jboss.tools.ws.creation.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.creation.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.ws.creation.core.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.creation.core.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ws.creation.core.test/pom.xml
+++ b/tests/org.jboss.tools.ws.creation.core.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.creation.core.test</artifactId>

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Localization: plugin
 Bundle-Name: %PLUGIN_NAME
 Bundle-Vendor: %PLUGIN_PROVIDER
 Bundle-SymbolicName: org.jboss.tools.ws.jaxrs.core.test;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.jaxrs.core.JBossJaxrsCoreTestPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.jboss.tools.ws.jaxrs.core;bundle-version="1.2.2",

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/pom.xml
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.jaxrs.core.test</artifactId>

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Localization: plugin
 Bundle-Name: %PLUGIN_NAME
 Bundle-Vendor: %PLUGIN_PROVIDER
 Bundle-SymbolicName: org.jboss.tools.ws.jaxrs.ui.test;singleton:=true
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.jaxrs.ui.JBossJaxrsUITestPlugin
 Require-Bundle: org.eclipse.core.runtime,
  org.jboss.tools.ws.jaxrs.ui,

--- a/tests/org.jboss.tools.ws.jaxrs.ui.test/pom.xml
+++ b/tests/org.jboss.tools.ws.jaxrs.ui.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.jaxrs.ui.test</artifactId>

--- a/tests/org.jboss.tools.ws.ui.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name.0
 Bundle-SymbolicName: org.jboss.tools.ws.ui.test
-Bundle-Version: 1.9.0.qualifier
+Bundle-Version: 1.9.1.qualifier
 Bundle-Activator: org.jboss.tools.ws.ui.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/tests/org.jboss.tools.ws.ui.test/pom.xml
+++ b/tests/org.jboss.tools.ws.ui.test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools.ws</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws.tests</groupId>
 	<artifactId>org.jboss.tools.ws.ui.test</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.tools</groupId>
 		<artifactId>ws</artifactId>
-		<version>1.9.0-SNAPSHOT</version>
+		<version>1.9.1-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Updated parent pom.xml and bumped version to 1.9.1-SNAPSHOT

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>