### PR TITLE
[JBDS-4133] - An internal error occurred during: "JAX-RS Metamodel build" - java.lang.NoClassDefFoundError: org/apache/lucene/analysis/standard/StandardAnalyzer

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0";visibility:=reex
  org.eclipse.wst.common.frameworks.ui;bundle-version="1.1.301",
  org.eclipse.jface.text;bundle-version="3.7.1",
  org.eclipse.jdt.core,
- org.apache.lucene.core;bundle-version="3.5.0";visibility:=reexport
+ org.apache.lucene.core;bundle-version="[3.5.0,4.0.0)";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.ws.jaxrs.core,


### PR DESCRIPTION
WARNING: was not able to test it on my dev machine because of a missing dependency. Check the status

- Change Lucene import from bundle to packages

Signed-off-by: Jeff MAURY <jmaury@redhat.com>