### PR TITLE
JBDS-4133 - Upgrade to Lucene 5.4.1

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
@@ -40,3 +40,6 @@ Export-Package: org.jboss.tools.ws.jaxrs.core,
  org.jboss.tools.ws.jaxrs.core.validation,
  org.jboss.tools.ws.jaxrs.core.wtp
 Bundle-ClassPath: .
+Import-Package: org.apache.lucene.analysis.standard;version="5.4.1",
+ org.apache.lucene.index;version="5.4.1",
+ org.apache.lucene.store;version="5.4.1"

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/domain/JaxrsMetamodel.java
@@ -942,11 +942,14 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 	@SuppressWarnings("unchecked")
 	private <T extends IJaxrsStatus> T searchJaxrsElement(Term... terms) {
 		final String matchingIdentifier = indexationService.searchElement(terms);
-		final T element = (T) this.elements.get(matchingIdentifier);
-		if (element == null) {
-			Logger.traceIndexing("No element matching terms", (Object[]) terms);
+		if(matchingIdentifier != null) {
+			final T element = (T) this.elements.get(matchingIdentifier);
+			if (element == null) {
+				Logger.traceIndexing("No element matching terms", (Object[]) terms);
+			}
+			return element;
 		}
-		return element;
+		return null;
 	}
 
 	/**
@@ -1272,7 +1275,10 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 			final Term categoryTerm = new Term(FIELD_TYPE, EnumElementCategory.APPLICATION.toString());
 			final Term kindTerm = new Term(FIELD_JAVA_APPLICATION, Boolean.TRUE.toString());
 			final String matchingIdentifier = indexationService.searchElement(classNameTerm, categoryTerm, kindTerm);
-			return (JaxrsJavaApplication) elements.get(matchingIdentifier);
+			if(matchingIdentifier != null) {
+				return (JaxrsJavaApplication) elements.get(matchingIdentifier);
+			}
+			return null;
 		} finally {
 			readWriteLock.readLock().unlock();
 		}
@@ -1307,7 +1313,10 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 			final Term categoryTerm = new Term(FIELD_TYPE, EnumElementCategory.APPLICATION.toString());
 			final Term kindTerm = new Term(FIELD_WEBXML_APPLICATION, Boolean.TRUE.toString());
 			final String elementIdentifier = indexationService.searchElement(categoryTerm, kindTerm);
-			return (JaxrsWebxmlApplication) elements.get(elementIdentifier);
+			if(elementIdentifier != null) {
+				return (JaxrsWebxmlApplication) elements.get(elementIdentifier);
+			}
+			return null;
 		} finally {
 			readWriteLock.readLock().unlock();
 		}
@@ -1327,7 +1336,10 @@ public class JaxrsMetamodel implements IJaxrsMetamodel {
 			final Term categoryTerm = new Term(FIELD_TYPE, EnumElementCategory.APPLICATION.toString());
 			final Term kindTerm = new Term(FIELD_WEBXML_APPLICATION, Boolean.TRUE.toString());
 			final String matchingIdentifier = indexationService.searchElement(classNameTerm, categoryTerm, kindTerm);
-			return (JaxrsWebxmlApplication) elements.get(matchingIdentifier);
+			if(matchingIdentifier != null) {
+				return (JaxrsWebxmlApplication) elements.get(matchingIdentifier);
+			}
+			return null;
 		} finally {
 			readWriteLock.readLock().unlock();
 		}

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/META-INF/MANIFEST.MF
@@ -41,3 +41,10 @@ Bundle-ClassPath: .,
  lib/mockito-core-1.9.0-rc1.jar,
  lib/objenesis-1.2.jar
 Export-Package: org.jboss.tools.ws.jaxrs.core.junitrules;x-friends:="org.jboss.tools.ws.jaxrs.ui.test"
+Import-Package: org.apache.lucene.analysis.standard;version="5.4.1",
+ org.apache.lucene.analysis;version="5.4.1",
+ org.apache.lucene.document;version="5.4.1", 
+ org.apache.lucene.index;version="5.4.1",
+ org.apache.lucene.search;version="5.4.1",
+ org.apache.lucene.store;version="5.4.1",
+ org.apache.lucene.util;version="5.4.1"

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/domain/JaxrsMetamodelLocatorTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/domain/JaxrsMetamodelLocatorTestCase.java
@@ -19,7 +19,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
-import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel;
+import org.jboss.tools.ws.jaxrs.core.internal.metamodel.domain.JaxrsMetamodel; 
 import org.jboss.tools.ws.jaxrs.core.junitrules.JaxrsMetamodelMonitor;
 import org.jboss.tools.ws.jaxrs.core.junitrules.WorkspaceSetupRule;
 import org.jboss.tools.ws.jaxrs.core.metamodel.domain.JaxrsMetamodelLocator;

--- a/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/indexation/LuceneIndexationTestCase.java
+++ b/tests/org.jboss.tools.ws.jaxrs.core.test/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/indexation/LuceneIndexationTestCase.java
@@ -24,17 +24,15 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.index.CorruptIndexException;
-import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
-import org.apache.lucene.queryParser.ParseException;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.util.Version;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.JavaModelException;
@@ -73,8 +71,8 @@ public class LuceneIndexationTestCase {
 	@Before
 	public void setup() throws CoreException, CorruptIndexException, IOException {
 		metamodelMonitor.getMetamodel();
-		analyzer = new StandardAnalyzer(Version.LUCENE_35);
-		config = new IndexWriterConfig(Version.LUCENE_35, analyzer);
+		analyzer = new StandardAnalyzer();
+		config = new IndexWriterConfig(analyzer);
 		index = new RAMDirectory();
 		w = new IndexWriter(index, config);
 		w.commit();
@@ -122,8 +120,8 @@ public class LuceneIndexationTestCase {
 	}
 
 
-	private IJaxrsElement query(String name, String value) throws CorruptIndexException, IOException, ParseException {
-		IndexReader reader = IndexReader.open(index);
+	private IJaxrsElement query(String name, String value) throws CorruptIndexException, IOException {
+		DirectoryReader reader = DirectoryReader.open(index);
 		IndexSearcher searcher = new IndexSearcher(reader);
 		try {
 			final TermQuery termQuery = new TermQuery(new Term("verb", value));
@@ -135,14 +133,12 @@ public class LuceneIndexationTestCase {
 			}
 			return null;
 		} finally {
-			searcher.close();
-
+			//searcher.close();
 		}
 	}
 
 	@Test
-	public void shouldRetrieveJaxrsHttpMethodFromVerb() throws IOException, JavaModelException, CoreException,
-			ParseException {
+	public void shouldRetrieveJaxrsHttpMethodFromVerb() throws IOException, JavaModelException, CoreException {
 		// pre-condition
 		final JaxrsHttpMethod httpMethod = metamodelMonitor.createHttpMethod("org.jboss.tools.ws.jaxrs.sample.services.FOO");
 		store(httpMethod);
@@ -156,7 +152,7 @@ public class LuceneIndexationTestCase {
 
 	@Test
 	public void shouldRetrieveJaxrsHttpMethodFromVerbAfterUpdate() throws IOException, JavaModelException,
-			CoreException, ParseException {
+			CoreException {
 		// pre-condition
 		final JaxrsHttpMethod httpMethod = metamodelMonitor.createHttpMethod("org.jboss.tools.ws.jaxrs.sample.services.FOO");
 		store(httpMethod);
@@ -176,7 +172,7 @@ public class LuceneIndexationTestCase {
 
 	@Test
 	public void shouldNotRetrieveJaxrsHttpMethodFromVerbAfterRemoval() throws IOException, JavaModelException,
-			CoreException, ParseException {
+			CoreException {
 		// pre-condition
 		final JaxrsHttpMethod httpMethod = metamodelMonitor.createHttpMethod("org.jboss.tools.ws.jaxrs.sample.services.FOO");
 		store(httpMethod);


### PR DESCRIPTION
Due to org.jboss.tools.ws.jaxrs.core :: error occurred during JAX-RS Metamodel build:
java.lang.NoClassDefFoundError: org/apache/lucene/analysis/standard/StandardAnalyzer

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>