### PR TITLE
JBIDE-24134org.jboss.tools.ws.reddeer...

### DIFF
--- a/features/org.jboss.tools.ws.test.feature/feature.xml
+++ b/features/org.jboss.tools.ws.test.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature 
     id="org.jboss.tools.ws.test.feature"
     label="%featureName"
-    version="1.9.3.qualifier"
+    version="1.9.100.qualifier"
     provider-name="%featureProvider"
     license-feature="org.jboss.tools.foundation.license.feature"
     license-feature-version="0.0.0">

--- a/features/org.jboss.tools.ws.test.feature/pom.xml
+++ b/features/org.jboss.tools.ws.test.feature/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<groupId>org.jboss.tools.ws.features</groupId>
 	<artifactId>org.jboss.tools.ws.test.feature</artifactId>
-
+	<version>1.9.100-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<build>

--- a/test-framework/org.jboss.tools.ws.reddeer/META-INF/MANIFEST.MF
+++ b/test-framework/org.jboss.tools.ws.reddeer/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer API for Webservices UI Tests
 Bundle-SymbolicName: org.jboss.tools.ws.reddeer
-Bundle-Version: 1.9.3.qualifier
+Bundle-Version: 1.9.100.qualifier
 Bundle-Activator: org.jboss.tools.ws.reddeer.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swt,
  org.hamcrest.core;bundle-version="1.3.0",
  org.jboss.reddeer.go;bundle-version="[1.2.0,2.0.0)",
- org.jboss.tools.common.reddeer;bundle-version="[3.8.3,3.9.0)",
+ org.jboss.tools.common.reddeer;bundle-version="[3.9.0,3.10.0)",
  org.jboss.tools.ws.ui
 Export-Package: org.jboss.tools.ws.reddeer.editor,
  org.jboss.tools.ws.reddeer.helper,

--- a/test-framework/org.jboss.tools.ws.reddeer/pom.xml
+++ b/test-framework/org.jboss.tools.ws.reddeer/pom.xml
@@ -9,6 +9,7 @@
 	</parent>
 	<groupId>org.jboss.tools.ws</groupId>
 	<artifactId>org.jboss.tools.ws.reddeer</artifactId>
+	<version>1.9.100-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>


### PR DESCRIPTION
JBIDE-24134 org.jboss.tools.ws.reddeer should depend on org.jboss.tools.common.reddeer 3.9.0 (master), not 3.8.3 (4.4.x); bump plugin and feature to 1.9.100

Signed-off-by: nickboldt <nboldt@redhat.com>