### PR TITLE
JBIDE-24997 attempt to use Lucene 7.1 (fails...

### DIFF
--- a/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0",
  org.eclipse.jdt.core;bundle-version="3.7.0",
  org.eclipse.jst.j2ee.web;bundle-version="1.1.301",
  org.eclipse.jst.j2ee;bundle-version="1.1.301",
- org.apache.lucene.core;bundle-version="[3.5.0,4.0.0)"
+ org.apache.lucene.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.tools.ws.jaxrs.core,

--- a/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/search/JaxrsElementsIndexationDelegate.java
+++ b/plugins/org.jboss.tools.ws.jaxrs.core/src/org/jboss/tools/ws/jaxrs/core/internal/metamodel/search/JaxrsElementsIndexationDelegate.java
@@ -79,8 +79,8 @@ public class JaxrsElementsIndexationDelegate {
 	public JaxrsElementsIndexationDelegate(final JaxrsMetamodel metamodel) throws CoreException {
 		try {
 			this.metamodel = metamodel;
-			analyzer = new StandardAnalyzer(Version.LUCENE_35);
-			config = new IndexWriterConfig(Version.LUCENE_35, analyzer);
+			analyzer = new StandardAnalyzer(Version.LUCENE_71);
+			config = new IndexWriterConfig(Version.LUCENE_71, analyzer);
 			config.setMaxBufferedDeleteTerms(1);
 			index = new RAMDirectory();
 			indexWriter = new IndexWriter(index, config);


### PR DESCRIPTION
JBIDE-24997 attempt to use Lucene 7.1 (fails to compile, requires migrating use of API to new version)

Signed-off-by: nickboldt <nboldt@redhat.com>